### PR TITLE
Limit query bug

### DIFF
--- a/src/renderer/components/Visualiser/VisualiserUtils.js
+++ b/src/renderer/components/Visualiser/VisualiserUtils.js
@@ -27,11 +27,15 @@ export function limitQuery(query) {
 
   // If there is no `get` the user mistyped the query
   if (getRegex.test(query)) {
-    const limitRegex = /.*;\s*(limit\b.*?;).*/;
+    const limitRegex = /(.*;\s*)(limit\b.*?;).*/;
     const offsetRegex = /.*;\s*(offset\b.*?;).*/;
     const deleteRegex = /^(.*;)\s*(delete\b.*;)$/;
 
-    if (!(offsetRegex.test(query)) && !(deleteRegex.test(query))) { limitedQuery = `${limitedQuery} offset 0;`; }
+    if (!(offsetRegex.test(query)) && !(deleteRegex.test(query)) && limitRegex.test(query)) { // if query does not contain offset and delete but does contain limit
+      limitedQuery = `${query.match(limitRegex)[1]}offset 0; ${query.match(limitRegex)[2]}`;
+    } else if (!(offsetRegex.test(query)) && !(deleteRegex.test(query)) && !limitRegex.test(query)) { // if query does not contain offset, delete and limit
+      limitedQuery = `${limitedQuery} offset 0;`;
+    }
     if (!(limitRegex.test(query)) && !(deleteRegex.test(query))) { limitedQuery = `${limitedQuery} limit ${QuerySettings.getQueryLimit()};`; }
   }
   return limitedQuery;

--- a/test/unit/components/Visualiser/VisualiserUtils.test.js
+++ b/test/unit/components/Visualiser/VisualiserUtils.test.js
@@ -20,7 +20,7 @@ describe('limit Query', () => {
   test('add offset to query already containing limit', () => {
     const query = 'match $x isa person; get; limit 40;';
     const limited = limitQuery(query);
-    expect(limited).toBe('match $x isa person; get; limit 40; offset 0;');
+    expect(limited).toBe('match $x isa person; get; offset 0; limit 40;');
   });
   test('add limit to query already containing offset', () => {
     const query = 'match $x isa person; get; offset 20;';
@@ -33,7 +33,7 @@ describe('limit Query', () => {
     expect(limited).toBe(query);
   });
   test('query already containing offset and limit in inverted order does not get changed', () => {
-    const query = 'match $x isa person; get; limit 40; offset 0;';
+    const query = 'match $x isa person; get; offset 0; limit 40;';
     const limited = limitQuery(query);
     expect(limited).toBe(query);
   });


### PR DESCRIPTION
## What is the goal of this PR?
To put offset before limit when a query contains only a limit entered by the user.

## What are the changes implemented in this PR?
Edit limit regex to extract query without limit
Create a condition where a query contains a limit but no offset so an offset can be placed between the query and limit.