### PR TITLE
Conjunction explanation bug

### DIFF
--- a/src/renderer/components/Visualiser/VisualiserGraphBuilder.js
+++ b/src/renderer/components/Visualiser/VisualiserGraphBuilder.js
@@ -10,6 +10,19 @@ import QuerySettings from './RightBar/SettingsTab/QuerySettings';
 // Map graql variables and explanations to each concept
 function attachExplanation(result) {
   return result.map((x) => {
+    if (x.explanation() && x.explanation().queryPattern() === '') { // if explantion is formed from a conjuction go one level deeper and attach explanations for each answer individually
+      return Array.from(x.explanation().answers()).flatMap((ans) => {
+        const exp = ans.explanation();
+        const key = ans.map().keys().next().value;
+        return Array.from(ans.map().values()).flatMap((y) => {
+          y.explanation = exp;
+          y.graqlVar = key;
+          return y;
+        });
+      }).flatMap(x => x);
+    }
+
+    // else explanation of query respose is same for all concepts in map
     const exp = x.explanation();
     const key = x.map().keys().next().value;
 

--- a/test/helpers/MockConcepts.js
+++ b/test/helpers/MockConcepts.js
@@ -138,7 +138,7 @@ const getMockQueryPattern1 = '{(child: $c1, parent: $p) isa parentship;}';
 
 function getMockAnswer2() {
   return {
-    explanation: () => 'mockExplanation',
+    explanation: () => ({ answers: () => [getMockAnswer1()], queryPattern: () => 'mock pattern' }),
     map: () => {
       const map = new Map();
       map.set('c', getMockEntity1());
@@ -195,7 +195,7 @@ function getMockAnswerContainingImplicitType() {
 
 function getMockAnswerContainingRelation() {
   return {
-    explanation: () => 'mockExplanation',
+    explanation: () => ({ answers: () => [getMockAnswer1()], queryPattern: () => 'mock pattern' }),
     map: () => {
       const map = new Map();
       map.set('r', getMockRelation());

--- a/test/unit/components/Visualiser/VisualiserGraphBuilder.test.js
+++ b/test/unit/components/Visualiser/VisualiserGraphBuilder.test.js
@@ -59,11 +59,10 @@ describe('buildFromConceptMap', () => {
 
     expect(data.nodes).toHaveLength(6);
     expect(data.edges).toHaveLength(4);
-
-    expect(data.nodes[0].explanation).toBe('mockExplanation');
-    expect(data.nodes[1].explanation).toBe('mockExplanation');
-    expect(data.nodes[2].explanation).toBe('mockExplanation');
-    expect(data.nodes[3].explanation).toBe('mockExplanation');
+    expect(data.nodes[0].explanation).toBeDefined();
+    expect(data.nodes[1].explanation).toBeDefined();
+    expect(data.nodes[2].explanation).toBeDefined();
+    expect(data.nodes[3].explanation).toBeDefined();
 
     expect(data.nodes[1].label).toBeDefined();
     expect(data.nodes[2].label).toBeDefined();

--- a/test/unit/components/Visualiser/VisualiserUtils.test.js
+++ b/test/unit/components/Visualiser/VisualiserUtils.test.js
@@ -130,8 +130,8 @@ describe('Get neighbours data', () => {
 
     expect(neighboursData.nodes).toHaveLength(2);
     expect(neighboursData.edges).toHaveLength(2);
-    expect(JSON.stringify(neighboursData.nodes[0])).toBe('{"baseType":"RELATION","id":"6666","explanation":"mockExplanation","offset":0,"graqlVar":"r"}');
-    expect(JSON.stringify(neighboursData.nodes[1])).toBe('{"baseType":"ENTITY","id":"4444","explanation":"mockExplanation","graqlVar":"r"}');
+    expect(JSON.stringify(neighboursData.nodes[0])).toBe('{"baseType":"RELATION","id":"6666","explanation":{},"offset":0,"graqlVar":"r"}');
+    expect(JSON.stringify(neighboursData.nodes[1])).toBe('{"baseType":"ENTITY","id":"4444","explanation":{},"graqlVar":"r"}');
     expect(JSON.stringify(neighboursData.edges[0])).toBe('{"from":"6666","to":"3333","label":"son"}');
     expect(JSON.stringify(neighboursData.edges[1])).toBe('{"from":"6666","to":"4444","label":"father"}');
   });


### PR DESCRIPTION
## What is the goal of this PR?
closes: #79

## What are the changes implemented in this PR?
Check if the response from Grakn is a conjunction by checking the query pattern (which will be empty).
Then go inside the answers of the explanation and attach the explanation (pertaining to the individual conjunction statement) to the concepts. 