### PR TITLE
Explanation bug - When explanation answer contains a relationship and its attribute

### DIFF
--- a/src/renderer/components/Visualiser/VisualiserUtils.js
+++ b/src/renderer/components/Visualiser/VisualiserUtils.js
@@ -55,11 +55,10 @@ export function buildExplanationQuery(answer, queryPattern) {
         attributeType = attributeType[0].slice(1, attributeType[0].indexOf(':'));
         attributeQuery = `has ${attributeType} $${graqlVar};`;
       }
-      // attributeQuery = `has ${queryPattern.match(/(?:has )(\w+)/)[1]} $${graqlVar};`;
     } else if (concept.isEntity()) {
       query += `$${graqlVar} id ${concept.id}; `;
-    } else if (attributeQuery && concept.isRelation()) { // if answer has a relation and attribute
-      attributeQuery = `$${graqlVar} id ${concept.id} ${attributeQuery}`;
+    } else if (concept.isRelation()) {
+      query += `$${graqlVar} id ${concept.id}; `;
     }
   });
   return { query, attributeQuery };

--- a/test/unit/components/Visualiser/VisualiserUtils.test.js
+++ b/test/unit/components/Visualiser/VisualiserUtils.test.js
@@ -89,13 +89,13 @@ describe('Build Explanation Query', () => {
   });
   test('from entity and relation', async () => {
     const explanationQuery = buildExplanationQuery(MockConcepts.getMockAnswer3(), MockConcepts.getMockQueryPattern3);
-    expect(explanationQuery.query).toBe('match $p id 3333; $c id 4444; ');
+    expect(explanationQuery.query).toBe('match $p id 3333; $c id 4444; $1234 id 6666; ');
     expect(explanationQuery.attributeQuery).toBe(null);
   });
   test('from attribute and relation', async () => {
     const explanationQuery = buildExplanationQuery(MockConcepts.getMockAnswer4(), MockConcepts.getMockQueryPattern4);
-    expect(explanationQuery.query).toBe('match ');
-    expect(explanationQuery.attributeQuery).toBe('$5678 id 6666 has duration $1234;');
+    expect(explanationQuery.query).toBe('match $5678 id 6666; ');
+    expect(explanationQuery.attributeQuery).toBe('has duration $1234;');
   });
 });
 


### PR DESCRIPTION
## What is the goal of this PR?
Fixes a bug, when an explanation comprises of a relation and its attribute, construct valid queries.

## What are the changes implemented in this PR?
When explanation answers contains a relation, create a query rather than an attribute query. 
This way the order of concept wont matter and a query will be constructed more robustly. 
