### PR TITLE
Revert deploy_github which can't be used due to issue #17

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,14 +150,18 @@ jobs:
       - checkout
       - install-bazel-linux
       - run: bazel run @graknlabs_build_tools//ci:release-approval
-
+      
   release-github-draft:
-    machine: true
+    docker:
+      - image: cibuilds/github:0.10
     working_directory: ~/grakn
     steps:
-      - checkout
-      - install-bazel-linux
-      - run: bazel run //:deploy-github-zip -- ${GRABL_CREDENTIAL}
+      - attach_workspace:
+          at: ~/grakn
+      - run:
+          name: "Publish Draft Release on GitHub"
+          command: |
+            ghr -t ${GRABL_CREDENTIAL} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete -draft v$(cat VERSION) ./artifacts
 
   release-cleanup:
     machine: true


### PR DESCRIPTION
## What is the goal of this PR?
Revert `deploy_github` in `release-github-draft` and use `ghr` directly.

We can't use the `deploy_github` rule for uploading distributions on the Workbase repo due to https://github.com/graknlabs/workbase/issues/17

## What are the changes implemented in this PR?
Revert `deploy_github` in `release-github-draft` and use `ghr` directly.
