### PR TITLE
Fix build-tools error by installing python dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,7 +197,7 @@ workflows:
       - assemble-windows:
           filters:
             branches:
-              only: test-deployment-windows-bugfix # TODO: revert back to master before merging the PR
+              only: master
       - release-approval:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,7 +197,7 @@ workflows:
       - assemble-windows:
           filters:
             branches:
-              only: master
+              only: test-deployment-windows-bugfix # TODO: revert back to master before merging the PR
       - release-approval:
           filters:
             branches:

--- a/.circleci/windows/assemble.py
+++ b/.circleci/windows/assemble.py
@@ -144,6 +144,12 @@ try:
         'SETX PATH "%PATH%;C:\\tools\\msys64\\usr\\bin"'
     ]), instance_ip, 'circleci', instance_password)
 
+    lprint('[Remote]: installing python dependencies')
+    ssh(' && '.join([
+        'set PYTHONIOENCODING=UTF-8',
+        'pip install wheel'
+    ]), instance_ip, 'circleci', instance_password)
+    
     lprint('[Remote] Cloning workbase')
     ssh(' && '.join([
         'refreshenv',


### PR DESCRIPTION
## What is the goal of this PR?
Fix a Windows-specific build errors on the `assemble-windows` CI job (eg., [this one](https://circleci.com/gh/graknlabs/workbase/803)) which is caused by missing Python dependencies. 

Closes https://github.com/graknlabs/workbase/issues/88

## What are the changes implemented in this PR?
Install `wheel` on Windows:
```
pip install wheel
```
which is needed by the CI job