### PR TITLE
Fix Workbase Windows CI

### DIFF
--- a/.circleci/windows/assemble.py
+++ b/.circleci/windows/assemble.py
@@ -44,6 +44,7 @@ def scp(remote, local, ssh_host, ssh_user, ssh_pass):
         '-p',
         ssh_pass,
         'scp',
+        '-T',
         '{}@{}:"{}"'.format(ssh_user, ssh_host, remote),
         local,
     ])


### PR DESCRIPTION
## What is the goal of this PR?

Fixes copying of built Workbase for Windows from GCP to CircleCI

## What are the changes implemented in this PR?

Adds `-T` option to `scp` which suppresses strict filename check when copying from remote to host.
[ref](https://unix.stackexchange.com/questions/499958/why-does-scps-strict-filename-checking-reject-quoted-last-component-but-not-oth)

Given that our path contains spaces, we'd be better turning the check off rather than figuring out correct sequence for escaping all spaces. Also, we _do_ trust our own GCP host.