### PR TITLE
Add benchmark as transitive dependency

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -82,9 +82,11 @@ node_grpc_compile()
 # Load Grakn Core Dependencies #
 ################################
 
-load("@graknlabs_grakn_core//dependencies/graknlabs:dependencies.bzl", "graknlabs_graql", "graknlabs_client_java")
+load("@graknlabs_grakn_core//dependencies/graknlabs:dependencies.bzl",
+     "graknlabs_graql", "graknlabs_client_java", "graknlabs_benchmark")
 graknlabs_graql()
 graknlabs_client_java()
+graknlabs_benchmark()
 
 load("@graknlabs_grakn_core//dependencies/maven:dependencies.bzl", maven_dependencies_for_build = "maven_dependencies")
 maven_dependencies_for_build()


### PR DESCRIPTION
## What is the goal of this PR?
Fix breaking change caused by the introduction of `benchmark` repository as a Bazel git_repository dependency.

## What are the changes implemented in this PR?
One liner to include `graknlabs_benchmark()` dependency that allows the building of distribution `tar.gz` in CircleCI.