### PR TITLE
deploy_brew Caskroom deployment for Workbase

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -15,3 +15,14 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
+
+
+load("@graknlabs_bazel_distribution//brew:rules.bzl", "deploy_brew")
+
+deploy_brew(
+    name = "deploy-brew",
+    type = "cask",
+    deployment_properties = "@graknlabs_build_tools//:deployment.properties",
+    formula = "//config/brew:grakn-workbase.rb",
+    version_file = "//:VERSION"
+)

--- a/config/brew/BUILD
+++ b/config/brew/BUILD
@@ -16,18 +16,4 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
-
-def graknlabs_grakn_core():
-    git_repository(
-        name = "graknlabs_grakn_core",
-        remote = "https://github.com/graknlabs/grakn",
-        commit = "03158a7f2a48947b0198941222804b7c7e721139" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
-    )
-
-def graknlabs_build_tools():
-    git_repository(
-        name = "graknlabs_build_tools",
-        remote = "https://github.com/graknlabs/build-tools",
-        commit = "feb6e92b1bf698d00641c9f41a0e2915cf31f3ca", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
-    )
+exports_files(["grakn-workbase.rb"])

--- a/config/brew/grakn-workbase.rb
+++ b/config/brew/grakn-workbase.rb
@@ -1,0 +1,11 @@
+cask 'grakn-workbase' do
+  version '{version}'
+  sha256 '{sha256}'
+
+  url "https://github.com/graknlabs/workbase/releases/download/v{version}/grakn-workbase-{version}-mac.dmg"
+  name 'Grakn Workbase'
+  homepage 'https://grakn.ai/'
+
+  app "Grakn Workbase.app"
+
+end


### PR DESCRIPTION
## What is the goal of this PR?

Deploy Workbase to Caskroom (our custom tap)

## What are the changes implemented in this PR?

- Bump `@graknlabs_build_tools` version which includes changes in graknlabs/bazel-distribution#88
- Add Caskroom formula for Workbase
- Add `bazel` target to deploy to tap