### PR TITLE
Implement versioning as prebuild step

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,9 +148,11 @@
         "write-file-atomic": "2.4.1"
     },
     "scripts": {
+        "prebuild": "node version.js",
         "build": "node .electron-vue/build.js &&  electron-builder --publish never",
         "build:clean": "node ./node_modules/cross-env/dist/bin/cross-env.js BUILD_TARGET=clean node .electron-vue/build.js",
         "build:dir": "node .electron-vue/build.js && node ./node_modules/electron-builder/out/cli/cli.js --dir",
+        "postbuild": "git checkout HEAD version.js",
         "dev": "node .electron-vue/dev-runner.js",
         "e2e": "npm run pack && node ./node_modules/jest/bin/jest.js ./test/e2e --runInBand",
         "integration": "node ./node_modules/jest/bin/jest.js ./test/integration",
@@ -160,5 +162,5 @@
         "postinstall": "bash ./install-node-electron.sh",
         "unit": "node ./node_modules/jest/bin/jest.js ./test/unit"
     },
-    "version": "1.1.1"
+    "version": "0.0.0-development"
 }

--- a/version.js
+++ b/version.js
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+
+const package_json_filename = 'package.json';
+const version_filename = 'VERSION';
+
+const version = fs.readFileSync(version_filename).toString().trim();
+const packageJsonContent = fs.readFileSync(package_json_filename).toString();
+const packageJson = JSON.parse(packageJsonContent);
+
+packageJson['version'] = version;
+
+fs.writeFileSync(package_json_filename, JSON.stringify(packageJson, null, 4));


### PR DESCRIPTION
## What is the goal of this PR?

Fixes #109 (it will need re-releasing though)
Workbase version should be read from `VERSION`, just like in other repos

## What are the changes implemented in this PR?

`prebuild` stage invokes `version.js`
`version.js` puts contents of `VERSION` into `package.json`'s `version` field
`postbuild` stage returns the file to its initial state

`package.json` now contains placeholder instead of proper version so we don't forget that there's a script that generates it.