### PR TITLE
assemble-mac - Fix Apple certificate signing issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -221,10 +221,9 @@ workflows:
             - test-linux
             - test-mac
       - assemble-mac:
-          # TODO: enable the filter before merging to master
-          # filters:
-          #   branches:
-          #     only: master
+          filters:
+            branches:
+              only: master
           requires:
             - test-linux
             - test-mac

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,9 +105,11 @@ jobs:
     steps:
       - install-bazel-mac
       - checkout
-      - run: CSC_LINK="$APPLE_CODE_SIGNING_CERTIFICATE_URL" CSC_KEY_PASSWORD="$APPLE_CODE_SIGNING_PASSWORD"
       - run: bazel run @nodejs//:npm install
-      - run: bazel run @nodejs//:npm run build
+      - run: |
+          export CSC_LINK="$APPLE_CODE_SIGNING_CERTIFICATE_URL"
+          export CSC_KEY_PASSWORD="$APPLE_CODE_SIGNING_PASSWORD"
+          bazel run @nodejs//:npm run build
       - run: mkdir -p ~/distribution && mv ./build/*.dmg ~/distribution/grakn-workbase-mac-$(cat VERSION).dmg
       - persist_to_workspace:
           root: ~/distribution
@@ -219,9 +221,10 @@ workflows:
             - test-linux
             - test-mac
       - assemble-mac:
-          filters:
-            branches:
-              only: master
+          # TODO: enable the filter before merging to master
+          # filters:
+          #   branches:
+          #     only: master
           requires:
             - test-linux
             - test-mac


### PR DESCRIPTION
## What is the goal of this PR?
The Apple Certificate signing in the `assemble-mac` CI job is broken. This PR fixes that

## What are the changes implemented in this PR?
Define the environment variables containing the certificate appropriately