### PR TITLE
Fix retrieving of neighbours of a node

### DIFF
--- a/src/renderer/components/Visualiser/VisualiserUtils.js
+++ b/src/renderer/components/Visualiser/VisualiserUtils.js
@@ -175,7 +175,6 @@ export async function filterMaps(answers) { // Filter out ConceptMaps that conta
  */
 async function getFilteredNeighbourAnswers(node, graknTx, limit) {
   const query = getNeighboursQuery(node, limit);
-  debugger;
   const resultAnswers = await (await graknTx.query(query)).collect();
   const filteredResult = await filterMaps(resultAnswers);
   if (resultAnswers.length !== filteredResult.length) {

--- a/src/renderer/components/Visualiser/VisualiserUtils.js
+++ b/src/renderer/components/Visualiser/VisualiserUtils.js
@@ -9,13 +9,13 @@ function getNeighboursQuery(node, neighboursLimit) {
     case 'ENTITY_TYPE':
     case 'ATTRIBUTE_TYPE':
     case 'RELATION_TYPE':
-      return `match $x id "${node.id}"; $y isa $x; get $y; offset ${node.offset}; limit ${neighboursLimit};`;
+      return `match $x id ${node.id}; $y isa $x; get $y; offset ${node.offset}; limit ${neighboursLimit};`;
     case 'ENTITY':
-      return `match $x id "${node.id}"; $r ($x, $y); get $r, $y; offset ${node.offset}; limit ${neighboursLimit};`;
+      return `match $x id ${node.id}; $r ($x, $y); get $r, $y; offset ${node.offset}; limit ${neighboursLimit};`;
     case 'ATTRIBUTE':
-      return `match $x has attribute $y; $y id "${node.id}"; get $x; offset ${node.offset}; limit ${neighboursLimit};`;
+      return `match $x has attribute $y; $y id ${node.id}; get $x; offset ${node.offset}; limit ${neighboursLimit};`;
     case 'RELATION':
-      return `match $r id "${node.id}"; $r ($x, $y); get $x; offset ${node.offset}; limit ${neighboursLimit};`;
+      return `match $r id ${node.id}; $r ($x, $y); get $x; offset ${node.offset}; limit ${neighboursLimit};`;
     default:
       throw new Error(`Unrecognised baseType of thing: ${node.baseType}`);
   }
@@ -175,6 +175,7 @@ export async function filterMaps(answers) { // Filter out ConceptMaps that conta
  */
 async function getFilteredNeighbourAnswers(node, graknTx, limit) {
   const query = getNeighboursQuery(node, limit);
+  debugger;
   const resultAnswers = await (await graknTx.query(query)).collect();
   const filteredResult = await filterMaps(resultAnswers);
   if (resultAnswers.length !== filteredResult.length) {


### PR DESCRIPTION
## What is the goal of this PR?
To fix the bug of double clicking on nodes to retrieve neighbours

closes: #135 

## What are the changes implemented in this PR?
Remove quotes around the ID inside the query used to retrieve neighbours.