### PR TITLE
Shortest path bug

### DIFF
--- a/src/renderer/components/Visualiser/ContextMenu.vue
+++ b/src/renderer/components/Visualiser/ContextMenu.vue
@@ -57,7 +57,7 @@
       },
       computeShortestPath() {
         this.setContextMenu({ show: false, x: null, y: null });
-        this.setCurrentQuery(`compute path from "${this.selectedNodes[0].id}", to "${this.selectedNodes[1].id}";`);
+        this.setCurrentQuery(`compute path from ${this.selectedNodes[0].id}, to ${this.selectedNodes[1].id};`);
         this[RUN_CURRENT_QUERY]().catch((err) => { this.$notifyError(err, 'Run Query'); });
       },
     },

--- a/src/renderer/components/Visualiser/VisualiserGraphBuilder.js
+++ b/src/renderer/components/Visualiser/VisualiserGraphBuilder.js
@@ -257,10 +257,8 @@ async function buildFromConceptList(path, pathNodes) {
 
   const roleplayers = await relationsRolePlayers(relations);
 
-  roleplayers.nodes.filter(x => path.list().includes(x.id));
-  roleplayers.edges.filter(x => (path.list().includes(x.to) && path.list().includes(x.to)));
+  roleplayers.edges = roleplayers.edges.filter(x => (path.list().includes(x.from) && path.list().includes(x.to)));
 
-  data.nodes.push(...roleplayers.nodes);
   data.edges.push(...roleplayers.edges);
 
   data.edges.map(edge => Object.assign(edge, Style.computeShortestPathEdgeStyle()));

--- a/test/unit/components/Visualiser/VisualiserGraphBuilder.test.js
+++ b/test/unit/components/Visualiser/VisualiserGraphBuilder.test.js
@@ -84,7 +84,7 @@ describe('buildFromConceptList', () => {
 
     const data = await VisualiserGraphBuilder.buildFromConceptList(mockPath, mockPathNodes);
 
-    expect(data.nodes).toHaveLength(5);
+    expect(data.nodes).toHaveLength(3);
     expect(data.nodes[0].id).toBe('6666');
     expect(data.nodes[1].id).toBe('3333');
     expect(data.nodes[2].id).toBe('4444');


### PR DESCRIPTION
## What is the goal of this PR?
Fix shortest path feature in workbase

closes:  #138

## What are the changes implemented in this PR?
1) Remove quotes around the ID in the shortest path query
2) Do not load other role-players that take part in the relation that are not part of the path