### PR TITLE
multi-line query with limit bug fix

### DIFF
--- a/src/renderer/components/Visualiser/VisualiserUtils.js
+++ b/src/renderer/components/Visualiser/VisualiserUtils.js
@@ -27,7 +27,7 @@ export function limitQuery(query) {
 
   // If there is no `get` the user mistyped the query
   if (getRegex.test(query)) {
-    const limitRegex = /(.*;\s*)(limit\b.*?;).*/;
+    const limitRegex = /(.*\s.*;\s*)(limit\b.*?;).*/;
     const offsetRegex = /.*;\s*(offset\b.*?;).*/;
     const deleteRegex = /^(.*;)\s*(delete\b.*;)$/;
 

--- a/test/unit/components/Visualiser/VisualiserUtils.test.js
+++ b/test/unit/components/Visualiser/VisualiserUtils.test.js
@@ -62,6 +62,13 @@ describe('limit Query', () => {
     const limited = limitQuery(query);
     expect(limited).toBe('match $x isa person;');
   });
+  test('multiline query with only limit', () => {
+    const query = `match $x isa person;
+    get; limit 1;`;
+    const limited = limitQuery(query);
+    expect(limited).toBe(`match $x isa person;
+    get; offset 0; limit 1;`);
+  });
 });
 
 describe('Compute Attributes', () => {


### PR DESCRIPTION
## What is the goal of this PR?
To allow use to run multi-line queries with only the limit defined

closes #140

## What are the changes implemented in this PR?
Improve get regex to match multiline queries before the get as well.