### PR TITLE
Relations panel scroll bug (WIndows)

### DIFF
--- a/src/renderer/components/Visualiser/RightBar/ConceptInfoTab/RelationsPanel.vue
+++ b/src/renderer/components/Visualiser/RightBar/ConceptInfoTab/RelationsPanel.vue
@@ -247,7 +247,7 @@
         padding: var(--container-padding);
         display: flex;
         flex-direction: column;
-        overflow: scroll;
+        overflow: auto;
         justify-content: center;
         border-bottom: var(--container-darkest-border);
     }


### PR DESCRIPTION
## What is the goal of this PR?
To fix the scroll bar showing in the relations panel in Workbase Windows

closes: #149

## What are the changes implemented in this PR?
Modify overflow from scroll to auto