### PR TITLE
Disable test connection button when connection state is valid or invalid

### DIFF
--- a/src/renderer/components/shared/Preferences.vue
+++ b/src/renderer/components/shared/Preferences.vue
@@ -16,7 +16,7 @@
                     <input class="input" v-model="serverHost">
                     <h1 class="connection-label port">Port:</h1>
                     <input class="input" type="number" v-model="serverPort">
-                    <loading-button v-on:clicked="testConnection" :text="connectionTest" className="btn test-btn" :loading="connectionTest === 'testing'"></loading-button>
+                    <loading-button v-on:clicked="testConnection" :text="connectionTest" className="btn test-btn" :loading="connectionTest === 'testing'" :disabled="connectionTest !== 'Test'"></loading-button>
                 </div>
             </div>
 


### PR DESCRIPTION
## What is the goal of this PR?
To disallow the user from clicking the test connection button when the state of the connection is valid or invalid

closes #110

## What are the changes implemented in this PR?
Add disabled flag to element