### PR TITLE
Fix deploy-github CI job by adding missing Bazel installation step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,6 +174,7 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/distribution
+      - install-bazel-linux-rbe
       - checkout
       - run: |
           export RELEASE_NOTES_TOKEN=$REPO_GITHUB_TOKEN


### PR DESCRIPTION
## What is the goal of this PR?

Fix deploy-github CI job by adding missing Bazel installation step