### PR TITLE
Remove manual check of instances for unhasing an attribute

### DIFF
--- a/src/renderer/components/SchemaDesign/store/actions.js
+++ b/src/renderer/components/SchemaDesign/store/actions.js
@@ -291,10 +291,6 @@ export default {
   async [DELETE_ATTRIBUTE]({ state, dispatch }, payload) {
     let graknTx = await dispatch(OPEN_GRAKN_TX);
 
-    const type = await graknTx.getSchemaConcept(state.selectedNodes[0].label);
-
-    if (await (await type.instances()).next()) throw Error('Cannot remove attribute type from schema concept with instances.');
-
     await state.schemaHandler.deleteAttribute(payload);
 
     await dispatch(COMMIT_TX, graknTx)


### PR DESCRIPTION
## What is the goal of this PR?
To not manually check if a schema type has instances when un-hasing an attribute as Grakn now has this validation check.

closes: #35 

## What are the changes implemented in this PR?
Remove manual check for instances