### PR TITLE
Cancel post-processing when graph cleared or keyspace changed

### DIFF
--- a/src/renderer/components/SchemaDesign/store/actions.js
+++ b/src/renderer/components/SchemaDesign/store/actions.js
@@ -63,6 +63,7 @@ export default {
       await commit('graknSession', await rootState.grakn.session(keyspace));
       dispatch(UPDATE_METATYPE_INSTANCES);
       dispatch(LOAD_SCHEMA);
+      commit('shouldPostProcess', false);
     }
   },
 
@@ -114,9 +115,11 @@ export default {
       state.visFacade.addToCanvas({ nodes: data.nodes, edges: data.edges });
       state.visFacade.fitGraphToWindow();
 
-      nodes = await computeAttributes(nodes);
-      nodes = await computeRoles(nodes);
-      state.visFacade.updateNode(nodes);
+      if (state.shouldPostProcess) {
+        nodes = await computeAttributes(nodes);
+        nodes = await computeRoles(nodes);
+        state.visFacade.updateNode(nodes);
+      }
 
       graknTx.close();
       commit('loadingSchema', false);
@@ -175,10 +178,13 @@ export default {
 
     state.visFacade.addToCanvas({ nodes: data.nodes, edges: data.edges });
 
+    if (state.shouldPostProcess) {
     // attach attributes and roles to visnode and update on graph to render the right bar attributes
-    data.nodes = await computeAttributes(data.nodes);
-    data.nodes = await computeRoles(data.nodes);
-    state.visFacade.updateNode(data.nodes);
+      data.nodes = await computeAttributes(data.nodes);
+      data.nodes = await computeRoles(data.nodes);
+      state.visFacade.updateNode(data.nodes);
+    }
+
     graknTx.close();
   },
 
@@ -219,10 +225,12 @@ export default {
 
     state.visFacade.addToCanvas({ nodes: data.nodes, edges: data.edges });
 
+    if (state.shouldPostProcess) {
     // attach attributes and roles to visnode and update on graph to render the right bar attributes
-    data.nodes = await computeAttributes(data.nodes);
-    data.nodes = await computeRoles(data.nodes);
-    state.visFacade.updateNode(data.nodes);
+      data.nodes = await computeAttributes(data.nodes);
+      data.nodes = await computeRoles(data.nodes);
+      state.visFacade.updateNode(data.nodes);
+    }
     graknTx.close();
   },
 
@@ -402,10 +410,12 @@ export default {
 
     state.visFacade.addToCanvas({ nodes: data.nodes, edges: data.edges });
 
+    if (state.shouldPostProcess) {
     // attach attributes and roles to visnode and update on graph to render the right bar attributes
-    data.nodes = await computeAttributes(data.nodes);
-    data.nodes = await computeRoles(data.nodes);
-    state.visFacade.updateNode(data.nodes);
+      data.nodes = await computeAttributes(data.nodes);
+      data.nodes = await computeRoles(data.nodes);
+      state.visFacade.updateNode(data.nodes);
+    }
     graknTx.close();
   },
 

--- a/src/renderer/components/SchemaDesign/store/actions.js
+++ b/src/renderer/components/SchemaDesign/store/actions.js
@@ -91,6 +91,7 @@ export default {
     try {
       if (!state.visFacade) return;
       commit('loadingSchema', true);
+      commit('shouldPostProcess', true);
 
       const response = (await (await graknTx.query('match $x sub thing; get;')).collect());
 
@@ -135,7 +136,9 @@ export default {
     return graknTx.commit();
   },
 
-  async [DEFINE_ENTITY_TYPE]({ state, dispatch }, payload) {
+  async [DEFINE_ENTITY_TYPE]({ state, dispatch, commit }, payload) {
+    commit('shouldPostProcess', true);
+
     let graknTx = await dispatch(OPEN_GRAKN_TX);
 
     // define entity type
@@ -188,8 +191,9 @@ export default {
     graknTx.close();
   },
 
-  async [DEFINE_ATTRIBUTE_TYPE]({ state, dispatch }, payload) {
+  async [DEFINE_ATTRIBUTE_TYPE]({ state, dispatch, commit }, payload) {
     let graknTx = await dispatch(OPEN_GRAKN_TX);
+    commit('shouldPostProcess', true);
 
     // define entity type
     await state.schemaHandler.defineAttributeType(payload);
@@ -364,8 +368,10 @@ export default {
     graknTx.close();
   },
 
-  async [DEFINE_RELATION_TYPE]({ state, dispatch }, payload) {
+  async [DEFINE_RELATION_TYPE]({ state, dispatch, commit }, payload) {
     let graknTx = await dispatch(OPEN_GRAKN_TX);
+    commit('shouldPostProcess', true);
+
     await state.schemaHandler.defineRelationType(payload);
 
     // define and relate roles to relation type

--- a/src/renderer/components/SchemaDesign/store/getters.js
+++ b/src/renderer/components/SchemaDesign/store/getters.js
@@ -10,4 +10,5 @@ export default {
   loadingSchema: state => state.loadingSchema,
   schemaHandler: state => state.schemaHandler,
   visFacade: state => state.visFacade,
+  shouldPostProcess: state => state.shouldPostProcess,
 };

--- a/src/renderer/components/SchemaDesign/store/mutations.js
+++ b/src/renderer/components/SchemaDesign/store/mutations.js
@@ -34,4 +34,7 @@ export default {
   setSchemaHandler(state, schemaHandler) {
     state.schemaHandler = schemaHandler;
   },
+  shouldPostProcess(state, shouldPostProcess) {
+    state.shouldPostProcess = shouldPostProcess;
+  },
 };

--- a/src/renderer/components/SchemaDesign/store/state.js
+++ b/src/renderer/components/SchemaDesign/store/state.js
@@ -11,4 +11,5 @@ export default {
   canvasData: { entities: 0, attributes: 0, relations: 0 },
   contextMenu: { show: false, x: null, y: null },
   schemaHandler: undefined,
+  shouldPostProcess: true,
 };

--- a/src/renderer/components/Visualiser/store/actions.js
+++ b/src/renderer/components/Visualiser/store/actions.js
@@ -77,6 +77,8 @@ export default {
 
   async [LOAD_NEIGHBOURS]({ state, commit, dispatch }, { visNode, neighboursLimit }) {
     commit('loadingQuery', true);
+    commit('shouldPostProcess', true);
+
     const graknTx = await dispatch(OPEN_GRAKN_TX);
     const data = await getNeighboursData(visNode, graknTx, neighboursLimit);
     visNode.offset += neighboursLimit;
@@ -102,6 +104,8 @@ export default {
       const query = state.currentQuery;
       validateQuery(query);
       commit('loadingQuery', true);
+      commit('shouldPostProcess', true);
+
       const graknTx = await dispatch(OPEN_GRAKN_TX);
       const result = (await (await graknTx.query(query)).collect());
 
@@ -144,6 +148,8 @@ export default {
   },
   async [LOAD_ATTRIBUTES]({ state, commit, dispatch }, { visNode, neighboursLimit }) {
     commit('loadingQuery', true);
+    commit('shouldPostProcess', true);
+
     const query = `match $x id ${visNode.id}, has attribute $y; get $y; offset ${visNode.attrOffset}; limit ${neighboursLimit};`;
     state.visFacade.updateNode({ id: visNode.id, attrOffset: visNode.attrOffset + neighboursLimit });
 
@@ -182,6 +188,8 @@ export default {
     /* eslint-disable no-await-in-loop */
     for (const query of queries) { // eslint-disable-line
       commit('loadingQuery', true);
+      commit('shouldPostProcess', true);
+
       const graknTx = await dispatch(OPEN_GRAKN_TX);
       const result = (await (await graknTx.query(query)).collect());
 

--- a/src/renderer/components/Visualiser/store/getters.js
+++ b/src/renderer/components/Visualiser/store/getters.js
@@ -8,4 +8,5 @@ export default {
   canvasData: state => state.canvasData,
   isActive: state => (state.currentKeyspace !== null),
   contextMenu: state => state.contextMenu,
+  shouldPostProcess: state => state.shouldPostProcess,
 };

--- a/src/renderer/components/Visualiser/store/mutations.js
+++ b/src/renderer/components/Visualiser/store/mutations.js
@@ -34,4 +34,7 @@ export default {
   setContextMenu(state, contextMenu) {
     state.contextMenu = contextMenu;
   },
+  shouldPostProcess(state, shouldPostProcess) {
+    state.shouldPostProcess = shouldPostProcess;
+  },
 };

--- a/src/renderer/components/Visualiser/store/tabState.js
+++ b/src/renderer/components/Visualiser/store/tabState.js
@@ -13,6 +13,7 @@ export default {
       graknSession: undefined,
       canvasData: { entities: 0, attributes: 0, relations: 0 },
       contextMenu: { show: false, x: null, y: null },
+      shouldPostProcess: true,
     };
   },
 };


### PR DESCRIPTION
## What is the goal of this PR?
To stop the post processing of nodes and edges when the user clears the graph or changes the keyspace

closes: #171 

## What are the changes implemented in this PR?
Add a flag `shouldPostProcess` in the vuex state which is set to false whenever the action `CURRENT_KEYSPACE_CHANGED` or `CANVAS_RESET` are dispatched.
Check the flag whenever post processing is needed to be done