### PR TITLE
Notify user to wait for action before clearing the graph or switching keyspaces

### DIFF
--- a/src/renderer/components/Visualiser/TopBar/GraqlEditor/GraqlEditor.vue
+++ b/src/renderer/components/Visualiser/TopBar/GraqlEditor/GraqlEditor.vue
@@ -290,6 +290,7 @@ export default {
     },
     clearGraph() {
       if (!this.currentKeyspace) this.$emit('keyspace-not-selected');
+      else if (this.showSpinner) this.$notifyInfo('Please wait for action to complete');
       else {
         this[CANVAS_RESET]();
       }

--- a/src/renderer/components/shared/KeyspacesHandler.vue
+++ b/src/renderer/components/shared/KeyspacesHandler.vue
@@ -119,7 +119,7 @@ export default {
     // computed
     this.$options.computed = {
       ...(this.$options.computed || {}),
-      ...mapGetters(['currentKeyspace']),
+      ...mapGetters(['currentKeyspace', 'showSpinner']),
     };
 
     // methods
@@ -165,8 +165,12 @@ export default {
       this.showKeyspaceList = false;
     },
     toggleKeyspaceList() {
-      this.$emit('keyspace-selected');
-      this.showKeyspaceList = !this.showKeyspaceList;
+      if (this.showSpinner) {
+        this.$notifyInfo('Please wait for action to complete');
+      } else {
+        this.$emit('keyspace-selected');
+        this.showKeyspaceList = !this.showKeyspaceList;
+      }
     },
   },
 };


### PR DESCRIPTION
## What is the goal of this PR?
To not allow the user to clear the graph or switch keyspaces if an action is being performed

closes: #171 

## What are the changes implemented in this PR?
Check the value of `showSpinner` before clearing the graph or switching keyspaces