### PR TITLE
Removes check of instances when un-hasing an attribute from a concept type

### DIFF
--- a/src/renderer/components/SchemaDesign/store/actions.js
+++ b/src/renderer/components/SchemaDesign/store/actions.js
@@ -240,10 +240,6 @@ export default {
   async [DELETE_ATTRIBUTE]({ state, dispatch }, payload) {
     let graknTx = await dispatch(OPEN_GRAKN_TX);
 
-    const type = await graknTx.getSchemaConcept(state.selectedNodes[0].label);
-
-    if (await (await type.instances()).next()) throw Error('Cannot remove attribute type from schema concept with instances.');
-
     await state.schemaHandler.deleteAttribute(payload);
 
     await dispatch(COMMIT_TX, graknTx)


### PR DESCRIPTION
## What is the goal of this PR?
Removing the association between a concept type and attribute type can be done regardless of whether or not the attribute type has any instances. This check has now been removed from the Schema Designer.

closes: #35 

## What are the changes implemented in this PR?
Removes manual check for instances

> originally implemented by Syed