### PR TITLE
Shows labels and arrows on concept type answers and schema

### DIFF
--- a/src/renderer/components/CanvasVisualiser/Events.js
+++ b/src/renderer/components/CanvasVisualiser/Events.js
@@ -1,12 +1,10 @@
-const collect = (array, current) => array.concat(current);
 let selectedNodes = null;
 
 export function dimNotHighlightedNodesAndEdges(connectedNodes, connectedEdges) {
   const nodesToUpdate =
   this.getNode()
     .filter(x => !connectedNodes.includes(x.id))
-    .map(x => ({ id: x.id, color: x.color.dimmedColor, font: { color: x.font.dimmedColor } }))
-    .reduce(collect, []);
+    .map(x => ({ id: x.id, color: x.color.dimmedColor, font: { color: x.font.dimmedColor } }));
 
   const edgesToUpdate =
   this.getEdge()
@@ -16,8 +14,7 @@ export function dimNotHighlightedNodesAndEdges(connectedNodes, connectedEdges) {
         color: edge.color.color.replace('1)', '0.2)'),
         highlight: edge.color.highlight,
         hover: edge.color.hover,
-      } }))
-    .reduce(collect, []);
+      } }));
 
   this.updateEdge(edgesToUpdate);
   this.updateNode(nodesToUpdate);
@@ -27,8 +24,7 @@ export function setDefaultColoursOnDimmedElements(connectedNodes, connectedEdges
   const nodesToUpdate =
   this.getNode()
     .filter(x => !connectedNodes.includes(x.id))
-    .map(x => ({ id: x.id, color: x.colorClone, font: x.fontClone }))
-    .reduce(collect, []);
+    .map(x => ({ id: x.id, color: x.colorClone, font: x.fontClone }));
 
   const edgesToUpdate =
   this.getEdge()
@@ -38,7 +34,7 @@ export function setDefaultColoursOnDimmedElements(connectedNodes, connectedEdges
         color: edge.color.color.replace('0.2)', '1)'),
         highlight: edge.color.highlight,
         hover: edge.color.hover,
-      } })).reduce(collect, []);
+      } }));
 
   this.updateNode(nodesToUpdate);
   this.updateEdge(edgesToUpdate);
@@ -47,8 +43,7 @@ export function setDefaultColoursOnDimmedElements(connectedNodes, connectedEdges
 export function showEdgeLabels(edges) {
   const edgesToUpdate =
   edges.map(id => this.getEdge(id))
-    .map(edge => ({ id: edge.id, arrows: { to: { enabled: true, scaleFactor: 0.3 } }, label: edge.hiddenLabel }))
-    .reduce(collect, []);
+    .map(edge => ({ id: edge.id, arrows: { to: { enabled: true, scaleFactor: 0.3 } }, label: edge.hiddenLabel }));
 
   this.updateEdge(edgesToUpdate);
 }
@@ -56,8 +51,7 @@ export function showEdgeLabels(edges) {
 export function hideEdgeLabels(edges) {
   const edgesToUpdate =
   edges.map(id => this.getEdge(id))
-    .map(edge => ({ id: edge.id, arrows: { to: { enabled: false } }, label: '' }))
-    .reduce(collect, []);
+    .map(edge => ({ id: edge.id, arrows: { to: { enabled: false } }, label: '' }));
 
   this.updateEdge(edgesToUpdate);
 }
@@ -66,8 +60,7 @@ export function removeLabelsOnNotConncetedEdges(nodeId) {
   const connectedEdges = this.getNetwork().getConnectedEdges(nodeId);
   const edgesToUpdate = this.getEdge()
     .filter(x => !connectedEdges.includes(x.id))
-    .map(edge => ({ id: edge.id, arrows: { to: { enabled: false } }, label: '' }))
-    .reduce(collect, []);
+    .map(edge => ({ id: edge.id, arrows: { to: { enabled: false } }, label: '' }));
 
   this.updateEdge(edgesToUpdate);
 }

--- a/src/renderer/components/CanvasVisualiser/Events.js
+++ b/src/renderer/components/CanvasVisualiser/Events.js
@@ -41,36 +41,43 @@ export function setDefaultColoursOnDimmedElements(connectedNodes, connectedEdges
 }
 
 export function showEdgeLabels(edges) {
-  const edgesToUpdate =
-  edges.map(id => this.getEdge(id))
-    .map(edge => ({ id: edge.id, arrows: { to: { enabled: true, scaleFactor: 0.3 } }, label: edge.hiddenLabel }));
+  const edgesToUpdate = edges.map(edge => ({ ...edge, label: edge.hiddenLabel }));
+  this.updateEdge(edgesToUpdate);
+}
 
+export function showEdgeArrows(edges) {
+  const edgesToUpdate = edges.map(edge => ({ ...edge, arrows: { to: { enabled: true, scaleFactor: 0.3 } } }));
   this.updateEdge(edgesToUpdate);
 }
 
 export function hideEdgeLabels(edges) {
-  const edgesToUpdate =
-  edges.map(id => this.getEdge(id))
-    .map(edge => ({ id: edge.id, arrows: { to: { enabled: false } }, label: '' }));
-
+  const edgesToUpdate = edges.map(edge => ({ ...edge, label: '' }));
   this.updateEdge(edgesToUpdate);
 }
 
-export function removeLabelsOnNotConncetedEdges(nodeId) {
-  const connectedEdges = this.getNetwork().getConnectedEdges(nodeId);
-  const edgesToUpdate = this.getEdge()
-    .filter(x => !connectedEdges.includes(x.id))
-    .map(edge => ({ id: edge.id, arrows: { to: { enabled: false } }, label: '' }));
-
+export function hideEdgeArrows(edges) {
+  const edgesToUpdate = edges.map(edge => ({ ...edge, arrows: { to: { enabled: false } } }));
   this.updateEdge(edgesToUpdate);
 }
 
-export function showLabelsOnEdgesConnectedToNode(nodeId) {
-  const connectedEdges = this.getNetwork().getConnectedEdges(nodeId);
-  // Hide labels on ALL edges before showing the ones on connected edges
-  this.hideEdgeLabels(this.getEdge().map(x => x.id));
-  // Show labels on connected edges
-  this.showEdgeLabels(connectedEdges);
+export function bringFocusToEdgesConnectedToNode(nodeId) {
+  const connectedEdgeIds = this.getNetwork().getConnectedEdges(nodeId);
+  let connectedEdges = this.getEdge(connectedEdgeIds);
+
+  if (connectedEdges.length) {
+    if (connectedEdges[0].options.hideLabel) {
+      // Hide labels on ALL edges before showing the ones on connected edges
+      this.hideEdgeLabels(this.getEdge());
+      this.showEdgeLabels(connectedEdges);
+    }
+
+    connectedEdges = this.getEdge(connectedEdgeIds);
+    if (connectedEdges[0].options.hideArrow) {
+      // Hide arrow on ALL edges before showing the ones on connected edges
+      this.hideEdgeArrows(this.getEdge());
+      this.showEdgeArrows(connectedEdges);
+    }
+  }
 }
 
 /*
@@ -91,13 +98,13 @@ export function onDragStart(params) {
     this.updateNode({ id: nodeId, fixed: { x: false, y: false } });
   });
   const nodeId = params.nodes[0];
-  this.removeLabelsOnNotConncetedEdges(nodeId);
+  this.bringFocusToEdgesConnectedToNode(nodeId);
 }
 
 export function onSelectNode(params) {
   selectedNodes = params.nodes;
   const nodeId = params.nodes[0];
-  this.showLabelsOnEdgesConnectedToNode(nodeId);
+  this.bringFocusToEdgesConnectedToNode(nodeId);
 }
 
 export function onClick(params) {
@@ -107,17 +114,27 @@ export function onClick(params) {
 export function onContext(params) {
   const nodeId = this.getNetwork().getNodeAt(params.pointer.DOM);
   if (nodeId && !selectedNodes) {
-    this.showLabelsOnEdgesConnectedToNode(nodeId);
+    this.bringFocusToEdgesConnectedToNode(nodeId);
     this.getNetwork().selectNodes([nodeId], true);
   }
 }
 
 export function onHoverNode(params) {
   const nodeId = params.node;
-  const connectedEdges = this.getNetwork().getConnectedEdges(nodeId);
+  const connectedEdgeIds = this.getNetwork().getConnectedEdges(nodeId);
+  const connectedEdges = this.getEdge(connectedEdgeIds);
   let connectedNodes = this.getNetwork().getConnectedNodes(nodeId).concat(nodeId);
-  // Show labels on connected edges
-  this.showEdgeLabels(connectedEdges);
+
+  if (connectedEdges.length) {
+    if (connectedEdges[0].options.hideLabel) {
+      this.showEdgeLabels(connectedEdges);
+    }
+
+    if (connectedEdges[0].options.hideArrow) {
+      this.showEdgeArrows(connectedEdges);
+    }
+  }
+
   // Highlight neighbour nodes
   connectedNodes.forEach((id) => { this.highlightNode(id); });
 
@@ -125,7 +142,7 @@ export function onHoverNode(params) {
     connectedNodes = connectedNodes.concat(selectedNodes);
   }
   // Dim remaining nodes in network
-  this.dimNotHighlightedNodesAndEdges(connectedNodes, connectedEdges);
+  this.dimNotHighlightedNodesAndEdges(connectedNodes, connectedEdgeIds);
 }
 
 
@@ -134,9 +151,12 @@ export function onBlurNode(params) {
   const connectedEdges = [];
   // When node is deleted do not get connected edges
   if (this.nodeExists(nodeId)) {
-    const connectedEdges = this.getNetwork().getConnectedEdges(nodeId);
-    if (!this.getNetwork().getSelectedNodes().includes(nodeId)) {
-    // Hide labels on connected edges - if the blurred node is not selected
+    const connectedEdgeIds = this.getNetwork().getConnectedEdges(nodeId);
+    const connectedEdges = this.getEdge(connectedEdgeIds);
+    const isNodeSelected = this.getNetwork().getSelectedNodes().includes(nodeId);
+
+    if (!isNodeSelected && connectedEdges[0].options.hideLabel) {
+      // Hide labels on connected edges - if the blurred node is not selected
       this.hideEdgeLabels(connectedEdges);
     }
   }
@@ -151,8 +171,15 @@ export function onBlurNode(params) {
 export function onDeselectNode(params) {
   const nodeId = params.previousSelection.nodes[0];
   const connectedNodes = this.getNetwork().getConnectedNodes(nodeId).concat(nodeId);
-  // Hide labels on ALL edges before showing the ones on connected edges
-  this.hideEdgeLabels(this.getEdge().map(x => x.id));
+  const allEdges = this.getEdge();
+
+  if (allEdges.length && allEdges[0].options.hideLabel) {
+    this.hideEdgeLabels(allEdges);
+  }
+
+  if (allEdges.length && allEdges[0].options.hideArrow) {
+    this.hideEdgeArrows(allEdges);
+  }
   // Remove highlighting from neighbours nodes
   connectedNodes.forEach((id) => { this.removeHighlightNode(id); });
 }

--- a/src/renderer/components/CanvasVisualiser/Visualiser.js
+++ b/src/renderer/components/CanvasVisualiser/Visualiser.js
@@ -78,7 +78,7 @@ function edgesBetweenTwoNodes(a, b) {
 function addEdge(edge) {
   if (this.nodeExists(edge.from) && this.nodeExists(edge.to)
         && !this.alreadyConnected(edge.from, edge.to, edge.label)) {
-    this._edges.add(Object.assign(edge, { label: '', hiddenLabel: edge.label }));
+    this._edges.add(edge);
     this.checkParallelEdges(edge.from, edge.to);
   }
 }

--- a/src/renderer/components/SchemaDesign/Style.js
+++ b/src/renderer/components/SchemaDesign/Style.js
@@ -129,7 +129,6 @@ function computeEdgeStyle() {
     hoverWidth: 2,
     selectionWidth: 2,
     arrowStrikethrough: false,
-    arrows: { to: { enabled: false } },
     smooth: {
       enabled: false,
       forceDirection: 'none',

--- a/src/renderer/components/Visualiser/Style.js
+++ b/src/renderer/components/Visualiser/Style.js
@@ -230,7 +230,6 @@ function computeEdgeStyle() {
     hoverWidth: 2,
     selectionWidth: 2,
     arrowStrikethrough: false,
-    arrows: { to: { enabled: false } },
     smooth: {
       enabled: false,
       forceDirection: 'none',

--- a/src/renderer/components/Visualiser/store/actions.js
+++ b/src/renderer/components/Visualiser/store/actions.js
@@ -155,6 +155,8 @@ export default {
 
       graknTx.close();
 
+      // debugger;
+
       return { nodes, edges };
     } catch (e) {
       console.log(e);

--- a/src/renderer/components/shared/CanvasDataBuilder.js
+++ b/src/renderer/components/shared/CanvasDataBuilder.js
@@ -40,28 +40,45 @@ const shouldVisualiseType = async (type) => {
 };
 
 const getEdge = async (from, to, edgeType, label) => {
-  let edge;
+  const edge = { from: from.id, to: to.id };
 
   switch (edgeType) {
+    // TYPES
     case edgeTypes.type.PLAYS:
     case edgeTypes.type.RELATES:
-      edge = { from: from.id, to: to.id, label, options: { hideLabel: false, hideArrow: false } };
-      break;
-    case edgeTypes.instance.RELATES:
-    case edgeTypes.instance.PLAYS:
-      edge = { from: from.id, to: to.id, label, options: { hideLabel: true, hideArrow: true } };
+      edge.label = label;
+      edge.arrows = { to: { enabled: true } };
+      edge.options = { hideLabel: false, hideArrow: false };
       break;
     case edgeTypes.type.HAS:
-      edge = { from: from.id, to: to.id, label: 'has', options: { hideLabel: false, hideArrow: false } };
-      break;
-    case edgeTypes.instance.HAS:
-      edge = { from: from.id, to: to.id, label: 'has', options: { hideLabel: true, hideArrow: true } };
+      edge.label = 'has';
+      edge.arrows = { to: { enabled: true } };
+      edge.options = { hideLabel: false, hideArrow: false };
       break;
     case edgeTypes.type.SUB:
-      edge = { from: from.id, to: to.id, label: 'sub', options: { hideLabel: false, hideArrow: false } };
+      edge.label = 'sub';
+      edge.arrows = { to: { enabled: true } };
+      edge.options = { hideLabel: false, hideArrow: false };
+      break;
+    // INSTANCES
+    case edgeTypes.instance.RELATES:
+    case edgeTypes.instance.PLAYS:
+      edge.label = '';
+      edge.hiddenLabel = label;
+      edge.arrows = { to: { enable: false } };
+      edge.options = { hideLabel: true, hideArrow: true };
+      break;
+    case edgeTypes.instance.HAS:
+      edge.label = '';
+      edge.hiddenLabel = 'has';
+      edge.arrows = { to: { enable: false } };
+      edge.options = { hideLabel: true, hideArrow: true };
       break;
     case edgeTypes.instance.SUB:
-      edge = { from: from.id, to: to.id, label: 'sub', options: { hideLabel: true, hideArrow: true } };
+      edge.label = '';
+      edge.hiddenLabel = 'sub';
+      edge.arrows = { to: { enable: false } };
+      edge.options = { hideLabel: true, hideArrow: true };
       break;
     default:
       break;

--- a/src/renderer/components/shared/CanvasDataBuilder.js
+++ b/src/renderer/components/shared/CanvasDataBuilder.js
@@ -45,17 +45,23 @@ const getEdge = async (from, to, edgeType, label) => {
   switch (edgeType) {
     case edgeTypes.type.PLAYS:
     case edgeTypes.type.RELATES:
+      edge = { from: from.id, to: to.id, label, options: { hideLabel: false, hideArrow: false } };
+      break;
     case edgeTypes.instance.RELATES:
     case edgeTypes.instance.PLAYS:
-      edge = { from: from.id, to: to.id, label };
+      edge = { from: from.id, to: to.id, label, options: { hideLabel: true, hideArrow: true } };
       break;
     case edgeTypes.type.HAS:
+      edge = { from: from.id, to: to.id, label: 'has', options: { hideLabel: false, hideArrow: false } };
+      break;
     case edgeTypes.instance.HAS:
-      edge = { from: from.id, to: to.id, label: 'has' };
+      edge = { from: from.id, to: to.id, label: 'has', options: { hideLabel: true, hideArrow: true } };
       break;
     case edgeTypes.type.SUB:
+      edge = { from: from.id, to: to.id, label: 'sub', options: { hideLabel: false, hideArrow: false } };
+      break;
     case edgeTypes.instance.SUB:
-      edge = { from: from.id, to: to.id, label: 'sub' };
+      edge = { from: from.id, to: to.id, label: 'sub', options: { hideLabel: true, hideArrow: true } };
       break;
     default:
       break;

--- a/test/unit/components/shared/CanvasDataBuilder.test.js
+++ b/test/unit/components/shared/CanvasDataBuilder.test.js
@@ -163,7 +163,9 @@ describe('buildInstances', () => {
     expect(node.label).toEqual('some attribute type: some value');
     expect(node.offset).toEqual(0);
 
-    expect(edges).toEqual([{ from: 'ent-instance', label: 'has', to: 'attr-instance' }]);
+    expect(edges).toEqual([
+      { arrows: { to: { enable: false } }, from: 'ent-instance', hiddenLabel: 'has', label: '', options: { hideArrow: true, hideLabel: true }, to: 'attr-instance' },
+    ]);
   });
 
   test('when graql answer contains an explanation', async () => {
@@ -225,7 +227,7 @@ describe('buildInstances', () => {
     const { nodes, edges } = await CDB.buildTypes(answers);
 
     expect(nodes).toHaveLength(1);
-    expect(edges).toEqual([{ from: 'ent-type', label: 'has', to: 'attr-type' }]);
+    expect(edges).toEqual([{ arrows: { to: { enabled: true } }, from: 'ent-type', label: 'has', options: { hideArrow: false, hideLabel: false }, to: 'attr-type' }]);
   });
 
   test('when graql answer contains a type that owns the same attributes as its supertype that is not a meta type', async () => {
@@ -247,7 +249,7 @@ describe('buildInstances', () => {
     const { nodes, edges } = await CDB.buildTypes(answers);
 
     expect(nodes).toHaveLength(1);
-    expect(edges).toEqual([{ from: 'subtype', label: 'sub', to: 'supertype' }]);
+    expect(edges).toEqual([{ arrows: { to: { enabled: true } }, from: 'subtype', label: 'sub', options: { hideArrow: false, hideLabel: false }, to: 'supertype' }]);
   });
 
   test('when graql answer contains a type that extends its non-meta supertype by owning more attributes', async () => {
@@ -270,8 +272,8 @@ describe('buildInstances', () => {
 
     expect(nodes).toHaveLength(1);
     expect(edges).toEqual([
-      { from: 'ent-type', label: 'sub', to: 'supertype' },
-      { from: 'ent-type', label: 'has', to: 'the extra attribute' },
+      { arrows: { to: { enabled: true } }, from: 'ent-type', label: 'sub', options: { hideArrow: false, hideLabel: false }, to: 'supertype' },
+      { arrows: { to: { enabled: true } }, from: 'ent-type', label: 'has', options: { hideArrow: false, hideLabel: false }, to: 'the extra attribute' },
     ]);
   });
 
@@ -292,7 +294,7 @@ describe('buildInstances', () => {
     const answers = [getMockedAnswer([roleplayerType], null)];
     const { edges } = await CDB.buildTypes(answers);
 
-    expect(edges).toEqual([{ from: 'relation', to: 'roleplayer', label: 'role a' }]);
+    expect(edges).toEqual([{ arrows: { to: { enabled: true } }, from: 'relation', label: 'role a', options: { hideArrow: false, hideLabel: false }, to: 'roleplayer' }]);
   });
 
   test('when graql answer contains a relation type', async () => {
@@ -310,8 +312,8 @@ describe('buildInstances', () => {
     expect(nodes).toHaveLength(1);
 
     expect(edges).toEqual([
-      { from: 'rel-type', label: 'role a', to: 'ent-type' },
-      { from: 'rel-type', label: 'role b', to: 'attr-type' },
+      { arrows: { to: { enabled: true } }, from: 'rel-type', label: 'role a', options: { hideArrow: false, hideLabel: false }, to: 'ent-type' },
+      { arrows: { to: { enabled: true } }, from: 'rel-type', label: 'role b', options: { hideArrow: false, hideLabel: false }, to: 'attr-type' },
     ]);
   });
 


### PR DESCRIPTION
## What is the goal of this PR?
Makes the visualisation of the schema and concept type answers more informative by always showing labels and arrows on the edges.

## What are the changes implemented in this PR?
- removes the unnecassary `.reduce(collect, [])` statements in `CanvasVisualiser/Events.js`
- adds `arrows`, `hiddenLabel` and `options` properties to edges in the `CanvasDataBuilder`
- extracts and moves parts of `showEdgeLabels` and `hideEdgeLabels` implementation to `showEdgeArrows` and `hideEdgeArrows`
- renames `showLabelsOnEdgesConnectedToNode` to `bringFocusToEdgesConnectedToNode` and add to it conditions that tailor its implementation based on the options on the edge options
- adds conditional behaviour to `onDragStart`, `onHoverNode` and `onDeselectNode` based on edge options
- removes edge property manipulation in `Visualiser/SchemaDesign > Style` and `Visualiser > addEdge`
- modifies the unit tests of `CanvasDataBuilder` accordingly

resolves #173 