### PR TITLE
Fixes the bug with missing edge properties

### DIFF
--- a/src/renderer/components/Visualiser/VisualiserGraphBuilder.js
+++ b/src/renderer/components/Visualiser/VisualiserGraphBuilder.js
@@ -1,5 +1,6 @@
 import Style from './Style';
 import NodeSettings from './RightBar/SettingsTab/DisplaySettings';
+import CDB from '../shared/CanvasDataBuilder';
 
 // Map graql variables and explanations to each concept
 function attachExplanation(result) {
@@ -166,7 +167,7 @@ async function loadRolePlayers(relation, limitRolePlayers, limit, offset) {
       thing.attrOffset = 0;
 
       nodes.push(thing);
-      edges.push({ from: relation.id, to: thing.id, label: roleLabel });
+      edges.push(CDB.getEdge(relation, thing, CDB.edgeTypes.instance.PLAYS, roleLabel));
     }));
   });
   return Promise.all(promises).then((() => ({ nodes, edges })));

--- a/src/renderer/components/shared/CanvasDataBuilder.js
+++ b/src/renderer/components/shared/CanvasDataBuilder.js
@@ -17,7 +17,7 @@ const edgeTypes = {
     HAS: 'HAS_INSTANCE',
     PLAYS: 'PLAYS_IN_INSTANCE',
     RELATES: 'RELATES_TO_INSTANCE',
-    SUB: 'SUBS_INSTANCE',
+    ISA: 'SUBS_INSTANCE',
   },
 };
 
@@ -77,16 +77,15 @@ const getEdge = (from, to, edgeType, label) => {
       edge.arrows = { to: { enable: false } };
       edge.options = { hideLabel: true, hideArrow: true };
       break;
-    case edgeTypes.instance.SUB:
+    case edgeTypes.instance.ISA:
       edge.label = '';
-      edge.hiddenLabel = 'sub';
+      edge.hiddenLabel = 'isa';
       edge.arrows = { to: { enable: false } };
       edge.options = { hideLabel: true, hideArrow: true };
       break;
     default:
       throw new Error(`Edge type [${edgeType}] is not recoganised`);
   }
-
   return edge;
 };
 
@@ -460,4 +459,11 @@ export default {
   getTypeSubEdge,
   getTypeRelatesEdges,
   getTypeAttributeEdges,
+  // ideally the following functions should be private functions
+  // of this module. However, this can be the case only when this
+  // module becomes the only place that contains the logic for
+  // constructing the nodes and edges. This will require further
+  // refactoring
+  getEdge,
+  edgeTypes,
 };

--- a/test/unit/components/Visualiser/VisualiserGraphBuilder.test.js
+++ b/test/unit/components/Visualiser/VisualiserGraphBuilder.test.js
@@ -44,10 +44,10 @@ describe('relationsRolePlayers', () => {
     expect(roleplayers.nodes.filter(x => x.id === '4444')[0].label).toBe('person: 4444');
 
     expect(roleplayers.edges).toHaveLength(2);
-    expect(roleplayers.edges.filter(x => x.label === 'son')[0].from).toBe('6666');
-    expect(roleplayers.edges.filter(x => x.label === 'son')[0].to).toBe('3333');
-    expect(roleplayers.edges.filter(x => x.label === 'father')[0].from).toBe('6666');
-    expect(roleplayers.edges.filter(x => x.label === 'father')[0].to).toBe('4444');
+    expect(roleplayers.edges.filter(x => x.hiddenLabel === 'son')[0].from).toBe('6666');
+    expect(roleplayers.edges.filter(x => x.hiddenLabel === 'son')[0].to).toBe('3333');
+    expect(roleplayers.edges.filter(x => x.hiddenLabel === 'father')[0].from).toBe('6666');
+    expect(roleplayers.edges.filter(x => x.hiddenLabel === 'father')[0].to).toBe('4444');
   });
 });
 
@@ -64,9 +64,9 @@ describe('buildFromConceptList', () => {
     expect(data.nodes[2].id).toBe('4444');
 
     expect(data.edges).toHaveLength(2);
-    expect(data.edges.filter(x => x.label === 'son')[0].from).toBe('6666');
-    expect(data.edges.filter(x => x.label === 'son')[0].to).toBe('3333');
-    expect(data.edges.filter(x => x.label === 'father')[0].from).toBe('6666');
-    expect(data.edges.filter(x => x.label === 'father')[0].to).toBe('4444');
+    expect(data.edges.filter(x => x.hiddenLabel === 'son')[0].from).toBe('6666');
+    expect(data.edges.filter(x => x.hiddenLabel === 'son')[0].to).toBe('3333');
+    expect(data.edges.filter(x => x.hiddenLabel === 'father')[0].from).toBe('6666');
+    expect(data.edges.filter(x => x.hiddenLabel === 'father')[0].to).toBe('4444');
   });
 });

--- a/test/unit/components/Visualiser/VisualiserUtils.test.js
+++ b/test/unit/components/Visualiser/VisualiserUtils.test.js
@@ -127,7 +127,9 @@ describe('Get neighbours data', () => {
     expect(neighboursData.nodes).toHaveLength(1);
     expect(neighboursData.edges).toHaveLength(1);
     expect(JSON.stringify(neighboursData.nodes[0])).toBe('{"baseType":"ENTITY","id":"3333","offset":0,"graqlVar":"x"}');
-    expect(JSON.stringify(neighboursData.edges[0])).toBe('{"from":"3333","to":"0000","label":"isa"}');
+    expect(JSON.stringify(neighboursData.edges[0])).toBe(
+      '{"from":"3333","to":"0000","label":"","hiddenLabel":"isa","arrows":{"to":{"enable":false}},"options":{"hideLabel":true,"hideArrow":true}}',
+    );
   });
   test('entity', async () => {
     const mockGraknTx = {
@@ -139,8 +141,12 @@ describe('Get neighbours data', () => {
     expect(neighboursData.edges).toHaveLength(2);
     expect(JSON.stringify(neighboursData.nodes[0])).toBe('{"baseType":"RELATION","id":"6666","explanation":{},"offset":0,"graqlVar":"r"}');
     expect(JSON.stringify(neighboursData.nodes[1])).toBe('{"baseType":"ENTITY","id":"4444","explanation":{},"graqlVar":"r"}');
-    expect(JSON.stringify(neighboursData.edges[0])).toBe('{"from":"6666","to":"3333","label":"son"}');
-    expect(JSON.stringify(neighboursData.edges[1])).toBe('{"from":"6666","to":"4444","label":"father"}');
+    expect(JSON.stringify(neighboursData.edges[0])).toBe(
+      '{"from":"6666","to":"3333","label":"","hiddenLabel":"son","arrows":{"to":{"enable":false}},"options":{"hideLabel":true,"hideArrow":true}}',
+    );
+    expect(JSON.stringify(neighboursData.edges[1])).toBe(
+      '{"from":"6666","to":"4444","label":"","hiddenLabel":"father","arrows":{"to":{"enable":false}},"options":{"hideLabel":true,"hideArrow":true}}',
+    );
   });
   test('attribute', async () => {
     const mockGraknTx = {
@@ -151,7 +157,9 @@ describe('Get neighbours data', () => {
     expect(neighboursData.nodes).toHaveLength(1);
     expect(neighboursData.edges).toHaveLength(1);
     expect(JSON.stringify(neighboursData.nodes[0])).toBe('{"baseType":"ENTITY","id":"3333","offset":0,"graqlVar":"x"}');
-    expect(JSON.stringify(neighboursData.edges[0])).toBe('{"from":"3333","to":"5555","label":"has"}');
+    expect(JSON.stringify(neighboursData.edges[0])).toBe(
+      '{"from":"3333","to":"5555","label":"","hiddenLabel":"has","arrows":{"to":{"enable":false}},"options":{"hideLabel":true,"hideArrow":true}}',
+    );
   });
   test('relation', async () => {
     const mockGraknTx = {
@@ -163,7 +171,9 @@ describe('Get neighbours data', () => {
     expect(neighboursData.nodes).toHaveLength(1);
     expect(neighboursData.edges).toHaveLength(1);
     expect(JSON.stringify(neighboursData.nodes[0])).toBe('{"baseType":"ENTITY","id":"3333","offset":0,"graqlVar":"x"}');
-    expect(JSON.stringify(neighboursData.edges[0])).toBe('{"from":"6666","to":"3333","label":"son"}');
+    expect(JSON.stringify(neighboursData.edges[0])).toBe(
+      '{"from":"6666","to":"3333","label":"","hiddenLabel":"son","arrows":{"to":{"enable":false}},"options":{"hideLabel":true,"hideArrow":true}}',
+    );
   });
 });
 


### PR DESCRIPTION
Please replace every line in curly brackets ( { like this } ) with an appropriate description, and remove this line.

## What is the goal of this PR?
Fixes a bug with missing properties of the edge objects produced by double-clicking nodes. 

## What are the changes implemented in this PR?
- modifies the functions in the `VisualiserUtils` and `VisualiserGraphBuilder` modules to use the `getEdge` function of `CanvasDataBuilder`
fixes #215 
