### PR TITLE
Fixes a bug with hiding edges on deselecting nodes

### DIFF
--- a/src/renderer/components/CanvasVisualiser/Events.js
+++ b/src/renderer/components/CanvasVisualiser/Events.js
@@ -155,7 +155,7 @@ export function onBlurNode(params) {
     const connectedEdges = this.getEdge(connectedEdgeIds);
     const isNodeSelected = this.getNetwork().getSelectedNodes().includes(nodeId);
 
-    if (!isNodeSelected && connectedEdges[0].options.hideLabel) {
+    if (connectedEdges.length && !isNodeSelected && connectedEdges[0].options.hideLabel) {
       // Hide labels on connected edges - if the blurred node is not selected
       this.hideEdgeLabels(connectedEdges);
     }
@@ -171,12 +171,12 @@ export function onBlurNode(params) {
 export function onDeselectNode(params) {
   const nodeId = params.previousSelection.nodes[0];
   const connectedNodes = this.getNetwork().getConnectedNodes(nodeId).concat(nodeId);
-  const allEdges = this.getEdge();
-
+  let allEdges = this.getEdge();
   if (allEdges.length && allEdges[0].options.hideLabel) {
     this.hideEdgeLabels(allEdges);
   }
 
+  allEdges = this.getEdge();
   if (allEdges.length && allEdges[0].options.hideArrow) {
     this.hideEdgeArrows(allEdges);
   }


### PR DESCRIPTION
## What is the goal of this PR?
Fixes a bug where deselecting a node did not hide the label's according to the node's `options`. 

## What are the changes implemented in this PR?
- in `Events > onDeselectNode` re-fetches the updated node after hiding labels and before hiding arrows.