### PR TITLE
Fixes a bug with explaining inferred concepts

### DIFF
--- a/src/renderer/components/Visualiser/store/actions.js
+++ b/src/renderer/components/Visualiser/store/actions.js
@@ -212,7 +212,7 @@ export default {
 
       const data = await CDB.buildInstances(result);
 
-      const rpData = await CDB.buildRPInstances(result, false, graknTx);
+      const rpData = await CDB.buildRPInstances(result, data, false, graknTx);
       data.nodes.push(...rpData.nodes);
       data.edges.push(...rpData.edges);
 

--- a/src/renderer/components/shared/CanvasDataBuilder.js
+++ b/src/renderer/components/shared/CanvasDataBuilder.js
@@ -445,7 +445,7 @@ const buildRPInstances = async (answers, currentData, shouldLimit, graknTx) => {
   }
 
   // exclude any edges that have already been produced by this module (i.e. currentData)
-  edges = edges.filter(nEdge => !currentData.edges.some(cEdge => sameEdgeCriteria(cEdge, nEdge)));
+  if (currentData) edges = edges.filter(nEdge => !currentData.edges.some(cEdge => sameEdgeCriteria(cEdge, nEdge)));
 
   return { nodes, edges };
 };


### PR DESCRIPTION
## What is the goal of this PR?
Fixes a bug with missing parameter passed to that led to error on explaining inferred instances.

## What are the changes implemented in this PR?
- includes the missing parameter of `CDB> buildRPInstances` in `EXPLAIN_CONCEPT` visualiser action
