### PR TITLE
Adapt to latest @graknlabs_bazel_distribution

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -13,6 +13,17 @@ load("@graknlabs_build_tools//distribution:dependencies.bzl", "graknlabs_bazel_d
 graknlabs_bazel_distribution()
 
 
+##################################
+# Load Distribution dependencies #
+##################################
+
+load("@graknlabs_bazel_distribution//github:dependencies.bzl", "tcnksm_ghr")
+tcnksm_ghr()
+
+load("@graknlabs_bazel_distribution//common:dependencies.bzl", "bazelbuild_rules_pkg")
+bazelbuild_rules_pkg()
+
+
 ###########################
 # Load Bazel Dependencies #
 ###########################
@@ -79,11 +90,14 @@ node_grpc_compile()
 
 load("@graknlabs_grakn_core//dependencies/graknlabs:dependencies.bzl",
 "graknlabs_graql", "graknlabs_protocol",
-"graknlabs_client_java", "graknlabs_benchmark")
+"graknlabs_client_java", "graknlabs_benchmark",
+"graknlabs_console", "graknlabs_common")
 graknlabs_graql()
 graknlabs_protocol()
 graknlabs_client_java()
 graknlabs_benchmark()
+graknlabs_console()
+graknlabs_common()
 
 load("@graknlabs_grakn_core//dependencies/maven:dependencies.bzl",
 graknlabs_grakn_core_maven_dependencies = "maven_dependencies")

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -22,7 +22,7 @@ def graknlabs_build_tools():
     git_repository(
         name = "graknlabs_build_tools",
         remote = "https://github.com/graknlabs/build-tools",
-        commit = "5a7504a34050ba8f3d6d262bbf33cd0f1f45d67f", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
+        commit = "d909d8401650c404d6a56081297235e47783005e", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
     )
 
 def graknlabs_grakn_core():


### PR DESCRIPTION
## What is the goal of this PR?

Newest changes in `bazel-distribution` (graknlabs/bazel-distribution#181) are backwards-incompatible and cause CI to fail.

## What are the changes implemented in this PR?

- Bump `@graknlabs_build_tools`'s version
- Uses workspace macros from most recent `bazel-distribution` version
- Load `common` and `console` as they are needed to build `grakn-core-all` distribution used in tests