### PR TITLE
Use release-validate-deps to ensure that workbase depends on a released version of client-nodejs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -214,7 +214,7 @@ jobs:
     machine: true
     steps:
       - checkout
-      - run: git push --delete origin workbase-release-branch
+      - run: git push --delete https://$REPO_GITHUB_TOKEN@github.com/graknlabs/workbase $CIRCLE_BRANCH
 
 workflows:
   workbase:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,6 +165,15 @@ jobs:
           export RELEASE_APPROVAL_TOKEN=$REPO_GITHUB_TOKEN
           bazel run @graknlabs_build_tools//ci:release-approval
 
+  release-validate:
+    machine: true
+    steps:
+      - install-bazel-linux-rbe
+      - checkout
+      - run: |
+          bazel run @graknlabs_build_tools//ci:release-validate-deps -- \
+            graknlabs_client_nodejs
+
   deploy-github:
     machine: true
     working_directory: ~/workbase
@@ -253,10 +262,16 @@ workflows:
 
   workbase-release:
     jobs:
+      - release-validate:
+          filters:
+            branches:
+              only: workbase-release-branch
       - cache-distribution:
           filters:
             branches:
               only: workbase-release-branch
+          requires:
+            - release-validate
       - deploy-github:
           filters:
             branches:


### PR DESCRIPTION
## What is the goal of this PR?

We have added a validation step using `//ci:release-validate-deps` in order to ensure that biograkn is releasable only if it depends on a released version of Grakn Core