### PR TITLE
Avoid duplicate edges

### DIFF
--- a/src/renderer/components/CanvasVisualiser/Facade.js
+++ b/src/renderer/components/CanvasVisualiser/Facade.js
@@ -1,5 +1,4 @@
 import Visualiser from './Visualiser';
-import { sameEdgeCriteria } from '../shared/SharedUtils';
 /*
 * Creates a new object that can be used to interact with the visualiser graph
 * given a specific container(DOM element)
@@ -54,14 +53,18 @@ function deleteFromCanvas(nodeIds) {
  */
 
 function addToCanvas(data) {
+  const currentNodes = this.getAllNodes();
   data.nodes.forEach((node) => {
-    const styledNode = Object.assign(node, this.style.computeNodeStyle(node));
-    this.container.visualiser.addNode(styledNode);
+    const isDuplicate = currentNodes.some(currentNode => currentNode.id === node.id);
+    if (!isDuplicate) {
+      const styledNode = Object.assign(node, this.style.computeNodeStyle(node));
+      this.container.visualiser.addNode(styledNode);
+    }
   });
 
   const currentEdges = this.getAllEdges();
   data.edges.forEach((edge) => {
-    const isDuplicate = currentEdges.find(currentEdge => sameEdgeCriteria(currentEdge, edge)) !== undefined;
+    const isDuplicate = currentEdges.some(currentEdge => currentEdge.id === edge.id);
     if (!isDuplicate) {
       if (!edge.color) { Object.assign(edge, this.style.computeEdgeStyle(edge)); }
       this.container.visualiser.addEdge(edge);

--- a/src/renderer/components/Visualiser/VisualiserUtils.js
+++ b/src/renderer/components/Visualiser/VisualiserUtils.js
@@ -234,10 +234,8 @@ export async function getNeighboursData(visNode, graknTx, neighboursLimit) {
     case 'RELATION_TYPE':
       return { nodes, edges: getTypeNeighbourEdges(nodes, visNode) };
     case 'ENTITY':
-
       return { nodes, edges: await getEntityNeighbourEdges(nodes) };
     case 'RELATION':
-
       return { nodes, edges: await getRelationNeighbourEdges(nodes, graknTx, visNode) };
     case 'ATTRIBUTE':
       return { nodes, edges: getAttributeNeighbourEdges(nodes, visNode) };

--- a/src/renderer/components/Visualiser/store/actions.js
+++ b/src/renderer/components/Visualiser/store/actions.js
@@ -194,7 +194,6 @@ export default {
   },
   async [EXPLAIN_CONCEPT]({ state, dispatch, getters, commit }) {
     const explanation = getters.selectedNode.explanation;
-
     let queries;
     // If the explanation is formed from a conjuction inside a rule, go one step deeper to access the actual explanation
     if (!explanation.queryPattern().length) {
@@ -209,7 +208,6 @@ export default {
       const graknTx = await dispatch(OPEN_GRAKN_TX);
       const result = (await (await graknTx.query(query)).collect());
 
-
       const data = await CDB.buildInstances(result);
 
       const rpData = await CDB.buildRPInstances(result, data, false, graknTx);
@@ -222,7 +220,7 @@ export default {
       graknTx.close();
 
       state.visFacade.updateNode(nodesWithAttributes);
-      const styledEdges = data.edges.map(edge => Object.assign(edge, state.visStyle.computeExplanationEdgeStyle()));
+      const styledEdges = data.edges.map(edge => ({ ...edge, label: edge.hiddenLabel, ...state.visStyle.computeExplanationEdgeStyle() }));
       state.visFacade.updateEdge(styledEdges);
       commit('loadingQuery', false);
     }

--- a/src/renderer/components/shared/SharedUtils.js
+++ b/src/renderer/components/shared/SharedUtils.js
@@ -11,5 +11,3 @@ export const baseTypes = {
   RELATION_INSTANCE: 'RELATION',
   ATTRIBUTE_INSTANCE: 'ATTRIBUTE',
 };
-
-export const sameEdgeCriteria = (edgeA, edgeB) => edgeA.from === edgeB.from && edgeA.to === edgeB.to && edgeA.hiddenLabel === edgeB.hiddenLabel && edgeA.label === edgeB.label;

--- a/test/unit/components/Visualiser/VisualiserUtils.test.js
+++ b/test/unit/components/Visualiser/VisualiserUtils.test.js
@@ -126,9 +126,9 @@ describe('Get neighbours data', () => {
 
     expect(neighboursData.nodes).toHaveLength(1);
     expect(neighboursData.edges).toHaveLength(1);
-    expect(JSON.stringify(neighboursData.nodes[0])).toBe('{"baseType":"ENTITY","id":"3333","offset":0,"graqlVar":"x"}');
-    expect(JSON.stringify(neighboursData.edges[0])).toBe(
-      '{"from":"3333","to":"0000","label":"","hiddenLabel":"isa","arrows":{"to":{"enable":false}},"options":{"hideLabel":true,"hideArrow":true}}',
+    expect(neighboursData.nodes[0]).toMatchObject({ baseType: 'ENTITY', id: '3333', offset: 0, graqlVar: 'x' });
+    expect(neighboursData.edges[0]).toEqual(
+      { id: '3333-0000-isa', from: '3333', to: '0000', label: '', hiddenLabel: 'isa', arrows: { to: { enable: false } }, options: { hideLabel: true, hideArrow: true } },
     );
   });
   test('entity', async () => {
@@ -139,13 +139,13 @@ describe('Get neighbours data', () => {
 
     expect(neighboursData.nodes).toHaveLength(2);
     expect(neighboursData.edges).toHaveLength(2);
-    expect(JSON.stringify(neighboursData.nodes[0])).toBe('{"baseType":"RELATION","id":"6666","explanation":{},"offset":0,"graqlVar":"r"}');
-    expect(JSON.stringify(neighboursData.nodes[1])).toBe('{"baseType":"ENTITY","id":"4444","explanation":{},"graqlVar":"r"}');
-    expect(JSON.stringify(neighboursData.edges[0])).toBe(
-      '{"from":"6666","to":"3333","label":"","hiddenLabel":"son","arrows":{"to":{"enable":false}},"options":{"hideLabel":true,"hideArrow":true}}',
+    expect(neighboursData.nodes[0]).toMatchObject({ baseType: 'RELATION', id: '6666', explanation: {}, offset: 0, graqlVar: 'r' });
+    expect(neighboursData.nodes[1]).toMatchObject({ baseType: 'ENTITY', id: '4444', explanation: {}, graqlVar: 'r' });
+    expect(neighboursData.edges[0]).toEqual(
+      { id: '6666-3333-son', from: '6666', to: '3333', label: '', hiddenLabel: 'son', arrows: { to: { enable: false } }, options: { hideLabel: true, hideArrow: true } },
     );
-    expect(JSON.stringify(neighboursData.edges[1])).toBe(
-      '{"from":"6666","to":"4444","label":"","hiddenLabel":"father","arrows":{"to":{"enable":false}},"options":{"hideLabel":true,"hideArrow":true}}',
+    expect(neighboursData.edges[1]).toEqual(
+      { id: '6666-4444-father', from: '6666', to: '4444', label: '', hiddenLabel: 'father', arrows: { to: { enable: false } }, options: { hideLabel: true, hideArrow: true } },
     );
   });
   test('attribute', async () => {
@@ -156,9 +156,9 @@ describe('Get neighbours data', () => {
 
     expect(neighboursData.nodes).toHaveLength(1);
     expect(neighboursData.edges).toHaveLength(1);
-    expect(JSON.stringify(neighboursData.nodes[0])).toBe('{"baseType":"ENTITY","id":"3333","offset":0,"graqlVar":"x"}');
-    expect(JSON.stringify(neighboursData.edges[0])).toBe(
-      '{"from":"3333","to":"5555","label":"","hiddenLabel":"has","arrows":{"to":{"enable":false}},"options":{"hideLabel":true,"hideArrow":true}}',
+    expect(neighboursData.nodes[0]).toMatchObject({ baseType: 'ENTITY', id: '3333', offset: 0, graqlVar: 'x' });
+    expect(neighboursData.edges[0]).toEqual(
+      { id: '3333-5555-has', from: '3333', to: '5555', label: '', hiddenLabel: 'has', arrows: { to: { enable: false } }, options: { hideLabel: true, hideArrow: true } },
     );
   });
   test('relation', async () => {
@@ -170,9 +170,9 @@ describe('Get neighbours data', () => {
 
     expect(neighboursData.nodes).toHaveLength(1);
     expect(neighboursData.edges).toHaveLength(1);
-    expect(JSON.stringify(neighboursData.nodes[0])).toBe('{"baseType":"ENTITY","id":"3333","offset":0,"graqlVar":"x"}');
-    expect(JSON.stringify(neighboursData.edges[0])).toBe(
-      '{"from":"6666","to":"3333","label":"","hiddenLabel":"son","arrows":{"to":{"enable":false}},"options":{"hideLabel":true,"hideArrow":true}}',
+    expect(neighboursData.nodes[0]).toMatchObject({ baseType: 'ENTITY', id: '3333', offset: 0, graqlVar: 'x' });
+    expect(neighboursData.edges[0]).toEqual(
+      { id: '6666-3333-son', from: '6666', to: '3333', label: '', hiddenLabel: 'son', arrows: { to: { enable: false } }, options: { hideLabel: true, hideArrow: true } },
     );
   });
 });

--- a/test/unit/components/shared/CanvasDataBuilder.test.js
+++ b/test/unit/components/shared/CanvasDataBuilder.test.js
@@ -153,12 +153,15 @@ describe('buildInstances', () => {
     expect(node.label).toEqual('');
     expect(node.offset).toEqual(2);
 
-    expect(edges).toEqual([{ arrows: { to: { enable: false } },
+    expect(edges).toEqual([{
+      id: 'some relation-some entity-some role',
+      arrows: { to: { enable: false } },
       from: 'some relation',
       hiddenLabel: 'some role',
       label: '',
       options: { hideArrow: true, hideLabel: true },
-      to: 'some entity' }]);
+      to: 'some entity',
+    }]);
   });
 
   test('when graql answer contains an attribute', async () => {
@@ -178,9 +181,15 @@ describe('buildInstances', () => {
     expect(node.label).toEqual('some attribute type: some value');
     expect(node.offset).toEqual(0);
 
-    expect(edges).toEqual([
-      { arrows: { to: { enable: false } }, from: 'ent-instance', hiddenLabel: 'has', label: '', options: { hideArrow: true, hideLabel: true }, to: 'attr-instance' },
-    ]);
+    expect(edges).toEqual([{
+      id: 'ent-instance-attr-instance-has',
+      arrows: { to: { enable: false } },
+      from: 'ent-instance',
+      hiddenLabel: 'has',
+      label: '',
+      options: { hideArrow: true, hideLabel: true },
+      to: 'attr-instance',
+    }]);
   });
 
   test('when graql answer contains an explanation', async () => {
@@ -242,7 +251,14 @@ describe('buildInstances', () => {
     const { nodes, edges } = await CDB.buildTypes(answers);
 
     expect(nodes).toHaveLength(1);
-    expect(edges).toEqual([{ arrows: { to: { enabled: true } }, from: 'ent-type', label: 'has', options: { hideArrow: false, hideLabel: false }, to: 'attr-type' }]);
+    expect(edges).toEqual([{
+      id: 'ent-type-attr-type-has',
+      arrows: { to: { enabled: true } },
+      from: 'ent-type',
+      label: 'has',
+      options: { hideArrow: false, hideLabel: false },
+      to: 'attr-type',
+    }]);
   });
 
   test('when graql answer contains a type that owns the same attributes as its supertype that is not a meta type', async () => {
@@ -264,7 +280,14 @@ describe('buildInstances', () => {
     const { nodes, edges } = await CDB.buildTypes(answers);
 
     expect(nodes).toHaveLength(1);
-    expect(edges).toEqual([{ arrows: { to: { enabled: true } }, from: 'subtype', label: 'sub', options: { hideArrow: false, hideLabel: false }, to: 'supertype' }]);
+    expect(edges).toEqual([{
+      id: 'subtype-supertype-sub',
+      arrows: { to: { enabled: true } },
+      from: 'subtype',
+      label: 'sub',
+      options: { hideArrow: false, hideLabel: false },
+      to: 'supertype',
+    }]);
   });
 
   test('when graql answer contains a type that extends its non-meta supertype by owning more attributes', async () => {
@@ -287,8 +310,15 @@ describe('buildInstances', () => {
 
     expect(nodes).toHaveLength(1);
     expect(edges).toEqual([
-      { arrows: { to: { enabled: true } }, from: 'ent-type', label: 'sub', options: { hideArrow: false, hideLabel: false }, to: 'supertype' },
-      { arrows: { to: { enabled: true } }, from: 'ent-type', label: 'has', options: { hideArrow: false, hideLabel: false }, to: 'the extra attribute' },
+      { id: 'ent-type-supertype-sub', arrows: { to: { enabled: true } }, from: 'ent-type', label: 'sub', options: { hideArrow: false, hideLabel: false }, to: 'supertype' },
+      {
+        id: 'ent-type-the extra attribute-has',
+        arrows: { to: { enabled: true } },
+        from: 'ent-type',
+        label: 'has',
+        options: { hideArrow: false, hideLabel: false },
+        to: 'the extra attribute',
+      },
     ]);
   });
 
@@ -309,7 +339,14 @@ describe('buildInstances', () => {
     const answers = [getMockedAnswer([roleplayerType], null)];
     const { edges } = await CDB.buildTypes(answers);
 
-    expect(edges).toEqual([{ arrows: { to: { enabled: true } }, from: 'relation', label: 'role a', options: { hideArrow: false, hideLabel: false }, to: 'roleplayer' }]);
+    expect(edges).toEqual([{
+      id: 'relation-roleplayer-role a',
+      arrows: { to: { enabled: true } },
+      from: 'relation',
+      label: 'role a',
+      options: { hideArrow: false, hideLabel: false },
+      to: 'roleplayer',
+    }]);
   });
 
   test('when graql answer contains a relation type', async () => {
@@ -327,8 +364,8 @@ describe('buildInstances', () => {
     expect(nodes).toHaveLength(1);
 
     expect(edges).toEqual([
-      { arrows: { to: { enabled: true } }, from: 'rel-type', label: 'role a', options: { hideArrow: false, hideLabel: false }, to: 'ent-type' },
-      { arrows: { to: { enabled: true } }, from: 'rel-type', label: 'role b', options: { hideArrow: false, hideLabel: false }, to: 'attr-type' },
+      { id: 'rel-type-ent-type-role a', arrows: { to: { enabled: true } }, from: 'rel-type', label: 'role a', options: { hideArrow: false, hideLabel: false }, to: 'ent-type' },
+      { id: 'rel-type-attr-type-role b', arrows: { to: { enabled: true } }, from: 'rel-type', label: 'role b', options: { hideArrow: false, hideLabel: false }, to: 'attr-type' },
     ]);
   });
 


### PR DESCRIPTION
## What is the goal of this PR?
Although attended to in a previous PR, duplicate edges were still present when explaining an inferred concept. With the current implementation, deduplication of edges and nodes takes place just before drawing them which we hope to be a more reliable approach.

## What are the changes implemented in this PR?
- add (own) unique id in `edge` objects
- change same edge criteria to be the identical edge id values
- avoid adding duplicate edges and nodes in `Facade > addToCanvas`