### PR TITLE
Fixes a bug with missing properties on nodes produced by double clicking

### DIFF
--- a/src/renderer/components/CanvasVisualiser/Facade.js
+++ b/src/renderer/components/CanvasVisualiser/Facade.js
@@ -53,8 +53,8 @@ function deleteFromCanvas(nodeIds) {
  */
 
 function addToCanvas(data) {
-  const currentNodes = this.getAllNodes();
   data.nodes.forEach((node) => {
+    const currentNodes = this.getAllNodes();
     const isDuplicate = currentNodes.some(currentNode => currentNode.id === node.id);
     if (!isDuplicate) {
       const styledNode = Object.assign(node, this.style.computeNodeStyle(node));
@@ -62,8 +62,8 @@ function addToCanvas(data) {
     }
   });
 
-  const currentEdges = this.getAllEdges();
   data.edges.forEach((edge) => {
+    const currentEdges = this.getAllEdges();
     const isDuplicate = currentEdges.some(currentEdge => currentEdge.id === edge.id);
     if (!isDuplicate) {
       if (!edge.color) { Object.assign(edge, this.style.computeEdgeStyle(edge)); }

--- a/src/renderer/components/Visualiser/store/actions.js
+++ b/src/renderer/components/Visualiser/store/actions.js
@@ -21,7 +21,7 @@ import {
   validateQuery,
   computeAttributes,
   mapAnswerToExplanationQuery,
-  getNeighboursData,
+  getFilteredNeighbourAnswers,
 } from '../VisualiserUtils';
 import QuerySettings from '../RightBar/SettingsTab/QuerySettings';
 import VisualiserGraphBuilder from '../VisualiserGraphBuilder';
@@ -79,14 +79,14 @@ export default {
   async [LOAD_NEIGHBOURS]({ state, commit, dispatch }, { visNode, neighboursLimit }) {
     commit('loadingQuery', true);
     const graknTx = await dispatch(OPEN_GRAKN_TX);
-    const data = await getNeighboursData(visNode, graknTx, neighboursLimit);
+    const filteredResult = await getFilteredNeighbourAnswers(visNode, graknTx, neighboursLimit);
+    const data = await CDB.buildNeighbours(visNode, filteredResult, graknTx);
     visNode.offset += neighboursLimit;
     state.visFacade.updateNode(visNode);
     state.visFacade.addToCanvas(data);
     if (data.nodes.length) state.visFacade.fitGraphToWindow();
     commit('updateCanvasData');
-    const labelledNodes = await VisualiserGraphBuilder.prepareNodes(data.nodes);
-    const styledNodes = labelledNodes.map(node => Object.assign(node, state.visStyle.computeNodeStyle(node)));
+    const styledNodes = data.nodes.map(node => Object.assign(node, state.visStyle.computeNodeStyle(node)));
     state.visFacade.updateNode(styledNodes);
     const nodesWithAttribtues = await computeAttributes(data.nodes);
     state.visFacade.updateNode(nodesWithAttribtues);

--- a/test/e2e/helpers/utils.js
+++ b/test/e2e/helpers/utils.js
@@ -7,7 +7,7 @@ const GraknClient = require('grakn-client');
 // eslint-disable-next-line import/prefer-default-export
 export const waitUntil = criteria => new Promise(async (resolve, reject) => {
   const intervalTime = 1;
-  const iterations = 10000;
+  const iterations = 15000;
   let isFullfilled = false;
 
   await interval(async (iteration, stop) => {

--- a/test/helpers/mockedConcepts.js
+++ b/test/helpers/mockedConcepts.js
@@ -1,0 +1,122 @@
+const getMockedGraknTx = (answer, extraProps = {}) => ({
+  query: () => Promise.resolve({ collect: () => Promise.resolve(answer) }),
+  ...extraProps,
+});
+
+const getMockedExplanation = answers => ({ answers: () => answers });
+
+const getMockedAnswer = (concepts, explanation) => {
+  const answer = {};
+
+  const map = new Map();
+  concepts.forEach((concept, index) => { map.set(index, concept); });
+  answer.map = () => map;
+  answer.explanation = () => explanation;
+
+  return answer;
+};
+
+const mockedMetaType = {
+  isRole: () => false,
+  isType: () => true,
+  isThing: () => false,
+  isImplicit: () => Promise.resolve(false),
+  label: () => Promise.resolve('entity'),
+};
+
+const mockedRole = {
+  label: () => Promise.resolve('some-role'),
+};
+
+const mockedEntityType = {
+  id: 'ent-type',
+  baseType: 'ENTITY_TYPE',
+  isRole: () => false,
+  isType: () => true,
+  isThing: () => false,
+  label: () => Promise.resolve('some-entity-type'),
+  attributes: () => Promise.resolve({ collect: () => Promise.resolve([]) }),
+  isImplicit: () => Promise.resolve(false),
+  sup: () => Promise.resolve({ label: () => Promise.resolve('entity') }),
+  playing: () => Promise.resolve({ collect: () => Promise.resolve([]) }),
+};
+
+const mockedRelationType = {
+  id: 'rel-type',
+  baseType: 'RELATION_TYPE',
+  isRole: () => false,
+  isType: () => true,
+  isRelationType: () => true,
+  isThing: () => false,
+  label: () => Promise.resolve('some-relation-type'),
+  attributes: () => Promise.resolve({ collect: () => Promise.resolve([]) }),
+  isImplicit: () => Promise.resolve(false),
+  sup: () => Promise.resolve({ label: () => Promise.resolve('relation') }),
+  playing: () => Promise.resolve({ collect: () => Promise.resolve([]) }),
+};
+
+const mockedAttributeType = {
+  id: 'attr-type',
+  baseType: 'ATTRIBUTE_TYPE',
+  isRole: () => false,
+  isType: () => true,
+  isThing: () => false,
+  label: () => Promise.resolve('some-attribute-type'),
+  attributes: () => Promise.resolve({ collect: () => Promise.resolve([]) }),
+  isImplicit: () => Promise.resolve(false),
+  sup: () => Promise.resolve({ label: () => Promise.resolve('attribute') }),
+  playing: () => Promise.resolve({ collect: () => Promise.resolve([]) }),
+};
+
+const mockedEntityInstance = {
+  id: 'ent-instance',
+  baseType: 'ENTITY',
+  isRole: () => false,
+  isType: () => false,
+  isThing: () => true,
+  isEntity: () => true,
+  isAttribute: () => false,
+  isInferred: () => Promise.resolve(false),
+  type: () => Promise.resolve(mockedEntityType),
+  attributes: () => Promise.resolve({ collect: () => Promise.resolve([]) }),
+};
+
+const mockedRelationInstance = {
+  id: 'rel-instance',
+  baseType: 'RELATION',
+  isRole: () => false,
+  isType: () => false,
+  isThing: () => true,
+  isAttribute: () => false,
+  isEntity: () => false,
+  isRelation: () => true,
+  isInferred: () => Promise.resolve(false),
+  type: () => Promise.resolve(mockedRelationType),
+  attributes: () => Promise.resolve({ collect: () => Promise.resolve([]) }),
+};
+
+const mockedAttributeInstance = {
+  id: 'attr-instance',
+  baseType: 'ATTRIBUTE',
+  isRole: () => false,
+  isType: () => false,
+  isThing: () => true,
+  isAttribute: () => true,
+  isInferred: () => Promise.resolve(false),
+  type: () => Promise.resolve(mockedAttributeType),
+  value: () => Promise.resolve('some value'),
+};
+
+export {
+  getMockedGraknTx,
+  getMockedExplanation,
+  getMockedAnswer,
+  mockedMetaType,
+  mockedRole,
+  mockedEntityType,
+  mockedRelationType,
+  mockedAttributeType,
+  mockedEntityInstance,
+  mockedRelationInstance,
+  mockedAttributeInstance,
+};

--- a/test/unit/components/Visualiser/VisualiserUtils.test.js
+++ b/test/unit/components/Visualiser/VisualiserUtils.test.js
@@ -1,5 +1,19 @@
-import { limitQuery, buildExplanationQuery, computeAttributes, filterMaps, getNeighboursData, validateQuery } from '@/components/Visualiser/VisualiserUtils.js';
-import MockConcepts from '../../../helpers/MockConcepts';
+import {
+  limitQuery,
+  buildExplanationQuery,
+  computeAttributes,
+  filterMaps,
+  validateQuery,
+} from '@/components/Visualiser/VisualiserUtils.js';
+
+import {
+  mockedEntityType,
+  mockedAttributeType,
+  mockedEntityInstance,
+  getMockedAnswer,
+  mockedAttributeInstance,
+  mockedRelationInstance,
+} from '../../../helpers/mockedConcepts';
 
 Array.prototype.flatMap = function flat(lambda) { return Array.prototype.concat.apply([], this.map(lambda)); };
 
@@ -17,26 +31,31 @@ describe('limit Query', () => {
     const limited = limitQuery(query);
     expect(limited).toBe('match $x isa person; get; offset 0; limit 10;');
   });
+
   test('add offset to query already containing limit', () => {
     const query = 'match $x isa person; get; limit 40;';
     const limited = limitQuery(query);
     expect(limited).toBe('match $x isa person; get; offset 0; limit 40;');
   });
+
   test('add limit to query already containing offset', () => {
     const query = 'match $x isa person; get; offset 20;';
     const limited = limitQuery(query);
     expect(limited).toBe('match $x isa person; get; offset 20; limit 10;');
   });
+
   test('query already containing offset and limit does not get changed', () => {
     const query = 'match $x isa person; get; offset 0; limit 40;';
     const limited = limitQuery(query);
     expect(limited).toBe(query);
   });
+
   test('query already containing offset and limit in inverted order does not get changed', () => {
     const query = 'match $x isa person; get; offset 0; limit 40;';
     const limited = limitQuery(query);
     expect(limited).toBe(query);
   });
+
   test('query containing multi-line queries', () => {
     const query = `
     match $x isa person;
@@ -46,6 +65,7 @@ describe('limit Query', () => {
     match $x isa person;
     $r($x, $y); get; offset 0; limit 10;`);
   });
+
   test('query containing multi-line get query', () => {
     const query = `
     match $x isa person;
@@ -57,11 +77,13 @@ describe('limit Query', () => {
     get
          $x; offset 0; limit 10;`);
   });
+
   test('query without get', () => {
     const query = 'match $x isa person;';
     const limited = limitQuery(query);
     expect(limited).toBe('match $x isa person;');
   });
+
   test('multiline query with only limit', () => {
     const query = `match $x isa person;
     get; limit 1;`;
@@ -73,107 +95,100 @@ describe('limit Query', () => {
 
 describe('Compute Attributes', () => {
   test('attach attributes to type', async () => {
-    const nodes = await computeAttributes([MockConcepts.getMockEntityType()]);
-    expect(nodes[0].attributes[0].type).toBe('name');
+    const entityType = { ...mockedEntityType };
+    entityType.attributes = () => Promise.resolve({ collect: () => Promise.resolve([mockedAttributeType]) });
+
+    const nodes = await computeAttributes([entityType]);
+    expect(nodes[0].attributes).toHaveLength(1);
+
+    const attributeType = nodes[0].attributes[0];
+    expect(attributeType.type).toBe('some-attribute-type');
   });
+
   test('attach attributes to thing', async () => {
-    const nodes = await computeAttributes([MockConcepts.getMockEntity1()]);
-    expect(nodes[0].attributes[0].type).toBe('name');
-    expect(nodes[0].attributes[0].value).toBe('John');
+    const entityInstance = { ...mockedEntityInstance };
+    const attributeInstance = { ...mockedAttributeInstance };
+    entityInstance.attributes = () => Promise.resolve({ collect: () => Promise.resolve([attributeInstance]) });
+
+    const nodes = await computeAttributes([entityInstance]);
+    expect(nodes[0].attributes).toHaveLength(1);
+
+    expect(nodes[0].attributes[0].type).toBe('some-attribute-type');
+    expect(nodes[0].attributes[0].value).toBe('some value');
   });
 });
 
 describe('Build Explanation Query', () => {
   test('from two entities', async () => {
-    const explanationQuery = buildExplanationQuery(MockConcepts.getMockAnswer1(), MockConcepts.getMockQueryPattern1);
-    expect(explanationQuery.query).toBe('match $p id 3333; $c1 id 4444; ');
+    const fistEntityInstance = { ...mockedEntityInstance };
+    fistEntityInstance.id = 'ent-1';
+
+    const secondEntityInstance = { ...mockedEntityInstance };
+    secondEntityInstance.id = 'ent-2';
+
+    const answer = getMockedAnswer([fistEntityInstance, secondEntityInstance], null);
+    const explanationQuery = buildExplanationQuery(answer, '{(role-a: $0, role-b: $1) isa some-relation-type;}');
+
+    expect(explanationQuery.query).toBe('match $0 id ent-1; $1 id ent-2; ');
     expect(explanationQuery.attributeQuery).toBe(null);
   });
+
   test('from entity and attribute', async () => {
-    const explanationQuery = buildExplanationQuery(MockConcepts.getMockAnswer2(), MockConcepts.getMockQueryPattern2);
-    expect(explanationQuery.query).toBe('match $c id 3333; ');
-    expect(explanationQuery.attributeQuery).toBe('has gender $1234;');
+    const entityInstance = { ...mockedEntityInstance };
+    const attributeInstance = { ...mockedAttributeInstance };
+
+    const answer = getMockedAnswer([entityInstance, attributeInstance], null);
+    const explanationQuery = buildExplanationQuery(answer, '{$1 "male"; $0 has some-attribute-type $1; $0 id ent-instance;}');
+
+    expect(explanationQuery.query).toBe('match $0 id ent-instance; ');
+    expect(explanationQuery.attributeQuery).toBe('has some-attribute-type $1;');
   });
-  test('from entity and relation', async () => {
-    const explanationQuery = buildExplanationQuery(MockConcepts.getMockAnswer3(), MockConcepts.getMockQueryPattern3);
-    expect(explanationQuery.query).toBe('match $p id 3333; $c id 4444; $1234 id 6666; ');
+
+  test('from entities and relation', async () => {
+    const firstEntityInstance = { ...mockedEntityInstance };
+    firstEntityInstance.id = 'ent-1';
+    const secondEntityInstance = { ...mockedEntityInstance };
+    secondEntityInstance.id = 'ent-2';
+    const relationInstance = { ...mockedRelationInstance };
+    relationInstance.id = 'rel';
+
+    const answer = getMockedAnswer([firstEntityInstance, secondEntityInstance, relationInstance], null);
+    const explanationQuery = buildExplanationQuery(answer, '{$0 id ent-1; $1 id ent-2; $2 (role-a: $0, role-b: $1) isa some-relation-type;}');
+
+    expect(explanationQuery.query).toBe('match $0 id ent-1; $1 id ent-2; $2 id rel; ');
     expect(explanationQuery.attributeQuery).toBe(null);
   });
+
   test('from attribute and relation', async () => {
-    const explanationQuery = buildExplanationQuery(MockConcepts.getMockAnswer4(), MockConcepts.getMockQueryPattern4);
-    expect(explanationQuery.query).toBe('match $5678 id 6666; ');
-    expect(explanationQuery.attributeQuery).toBe('has duration $1234;');
+    const attributeInstance = { ...mockedAttributeInstance };
+    const relationInstance = { ...mockedRelationInstance };
+
+    const answer = getMockedAnswer([attributeInstance, relationInstance], null);
+
+    const explanationQuery = buildExplanationQuery(answer, '{$r has some-attribute-type $1544633775910879; $1544633775910879 < 120;}');
+    expect(explanationQuery.query).toBe('match $1 id rel-instance; ');
+    expect(explanationQuery.attributeQuery).toBe('has some-attribute-type $0;');
   });
 });
 
 describe('Filters out Answers that contain inferred concepts in their ConceptMap', () => {
   test('contains implicit type', async () => {
-    const containsImplicit = await filterMaps([MockConcepts.getMockAnswerContainingImplicitType(), MockConcepts.getMockAnswer1()]);
-    expect(containsImplicit).toHaveLength(1);
+    const nonImplicitInstance = { ...mockedEntityInstance };
+    const implicitInstance = { ...mockedRelationInstance };
+    implicitInstance.isImplicit = () => Promise.resolve(true);
+
+    const answer = getMockedAnswer([nonImplicitInstance, implicitInstance]);
+
+    const nonImplicitOnlyAnswer = await filterMaps([answer]);
+    expect(nonImplicitOnlyAnswer).toHaveLength(1);
   });
+
   test('does not contains implicit type', async () => {
-    const containsImplicit = await filterMaps([MockConcepts.getMockAnswer1(), MockConcepts.getMockAnswer2()]);
-    expect(containsImplicit).toHaveLength(2);
-  });
-});
+    const nonImplicitInstance = { ...mockedEntityInstance };
+    const answer = getMockedAnswer([nonImplicitInstance]);
 
-describe('Get neighbours data', () => {
-  test('type', async () => {
-    const mockGraknTx = {
-      query: () => Promise.resolve({ collect: () => Promise.resolve([MockConcepts.getMockAnswerContainingEntity()]) }),
-    };
-    const neighboursData = await getNeighboursData(MockConcepts.getMockEntityType(), mockGraknTx, 1);
-
-    expect(neighboursData.nodes).toHaveLength(1);
-    expect(neighboursData.edges).toHaveLength(1);
-    expect(neighboursData.nodes[0]).toMatchObject({ baseType: 'ENTITY', id: '3333', offset: 0, graqlVar: 'x' });
-    expect(neighboursData.edges[0]).toEqual(
-      { id: '3333-0000-isa', from: '3333', to: '0000', label: '', hiddenLabel: 'isa', arrows: { to: { enable: false } }, options: { hideLabel: true, hideArrow: true } },
-    );
-  });
-  test('entity', async () => {
-    const mockGraknTx = {
-      query: () => Promise.resolve({ collect: () => Promise.resolve([MockConcepts.getMockAnswerContainingRelation()]) }),
-    };
-    const neighboursData = await getNeighboursData(MockConcepts.getMockEntity1(), mockGraknTx, 1);
-
-    expect(neighboursData.nodes).toHaveLength(2);
-    expect(neighboursData.edges).toHaveLength(2);
-    expect(neighboursData.nodes[0]).toMatchObject({ baseType: 'RELATION', id: '6666', explanation: {}, offset: 0, graqlVar: 'r' });
-    expect(neighboursData.nodes[1]).toMatchObject({ baseType: 'ENTITY', id: '4444', explanation: {}, graqlVar: 'r' });
-    expect(neighboursData.edges[0]).toEqual(
-      { id: '6666-3333-son', from: '6666', to: '3333', label: '', hiddenLabel: 'son', arrows: { to: { enable: false } }, options: { hideLabel: true, hideArrow: true } },
-    );
-    expect(neighboursData.edges[1]).toEqual(
-      { id: '6666-4444-father', from: '6666', to: '4444', label: '', hiddenLabel: 'father', arrows: { to: { enable: false } }, options: { hideLabel: true, hideArrow: true } },
-    );
-  });
-  test('attribute', async () => {
-    const mockGraknTx = {
-      query: () => Promise.resolve({ collect: () => Promise.resolve([MockConcepts.getMockAnswerContainingEntity()]) }),
-    };
-    const neighboursData = await getNeighboursData(MockConcepts.getMockAttribute(), mockGraknTx, 1);
-
-    expect(neighboursData.nodes).toHaveLength(1);
-    expect(neighboursData.edges).toHaveLength(1);
-    expect(neighboursData.nodes[0]).toMatchObject({ baseType: 'ENTITY', id: '3333', offset: 0, graqlVar: 'x' });
-    expect(neighboursData.edges[0]).toEqual(
-      { id: '3333-5555-has', from: '3333', to: '5555', label: '', hiddenLabel: 'has', arrows: { to: { enable: false } }, options: { hideLabel: true, hideArrow: true } },
-    );
-  });
-  test('relation', async () => {
-    const mockGraknTx = {
-      query: () => Promise.resolve({ collect: () => Promise.resolve([MockConcepts.getMockAnswerContainingEntity()]) }),
-      getConcept: () => Promise.resolve((MockConcepts.getMockRelation())),
-    };
-    const neighboursData = await getNeighboursData(MockConcepts.getMockRelation(), mockGraknTx, 1);
-
-    expect(neighboursData.nodes).toHaveLength(1);
-    expect(neighboursData.edges).toHaveLength(1);
-    expect(neighboursData.nodes[0]).toMatchObject({ baseType: 'ENTITY', id: '3333', offset: 0, graqlVar: 'x' });
-    expect(neighboursData.edges[0]).toEqual(
-      { id: '6666-3333-son', from: '6666', to: '3333', label: '', hiddenLabel: 'son', arrows: { to: { enable: false } }, options: { hideLabel: true, hideArrow: true } },
-    );
+    const nonImplicitOnlyAnswer = await filterMaps([answer]);
+    expect(nonImplicitOnlyAnswer).toHaveLength(1);
   });
 });
 


### PR DESCRIPTION
## What is the goal of this PR?
The nodes added to the visualiser as the result of double-clicking on node now contain all expected properties. In addition, the logic for producing the neighbour nodes has now moved to the Canvas Data Builder, which leads to better maintainability and testability. 

## What are the changes implemented in this PR?
- moves functions related to loading neighbours to the `Canvas Data Builder`
- refactors the unit tests for loading neighbours to use the mocked concepts in the same way as they are used by the rest of the `CDB` unit tests
- improves the reliability of deduplication of nodes and edges in the `Facad`
- improves types, labels and/or values of mocked concepts 

**Note: ideally and eventually, we should only use the `mockedConcepts.js` (in place of `MockedConcepts.js` across all tests that require mocked concepts. This requires further refactoring to remove `MockedConcepts.js` as a dependency.**