### PR TITLE
Fixes the bug with loading relation neighbours when "load roleplayers" setting is on

### DIFF
--- a/src/renderer/components/Visualiser/VisualiserUtils.js
+++ b/src/renderer/components/Visualiser/VisualiserUtils.js
@@ -12,9 +12,8 @@ function getNeighboursQuery(node, neighboursLimit) {
       return `match $x id ${node.id}; $r ($x, $y); get $r, $y; offset ${node.offset}; limit ${neighboursLimit};`;
     case 'ATTRIBUTE':
       return `match $x has attribute $y; $y id ${node.id}; get $x; offset ${node.offset}; limit ${neighboursLimit};`;
-    case 'RELATION': {
-      return `match $r id ${node.id}; $r ($x, $y); get $x; offset ${node.offset}; limit ${neighboursLimit};`;
-    }
+    case 'RELATION':
+      return `match $r id ${node.id}; $r ($x, $y); get $x; offset ${node.offset}; limit ${node.offset + neighboursLimit};`;
     default:
       throw new Error(`Unrecognised baseType of thing: ${node.baseType}`);
   }


### PR DESCRIPTION
## What is the goal of this PR?
Loading a relation's neighbours now works as expected regardless of the `Load Roleplayers` status in the settings.

## What are the changes implemented in this PR?
- increments `limit`'s value by the node's `offset` in the query that retrieves neighbours of a relation instance.