### PR TITLE
Avoids building edges where its nodes are not visualised

### DIFF
--- a/src/renderer/components/shared/CanvasDataBuilder.js
+++ b/src/renderer/components/shared/CanvasDataBuilder.js
@@ -234,12 +234,9 @@ const buildInstances = async (answers) => {
 
   data = deduplicateConcepts(data);
 
-  const nodesPromises = Promise.all(data.filter(item => item.shouldVisualise).map(item => getInstanceNode(item.concept, item.graqlVar, item.explanation)));
-  const nodes = await nodesPromises;
+  const nodes = await Promise.all(data.filter(item => item.shouldVisualise).map(item => getInstanceNode(item.concept, item.graqlVar, item.explanation)));
   const nodeIds = nodes.map(node => node.id);
-  const edgesPromises = Promise.all(data.filter(item => item.shouldVisualise).map(item => getInstanceEdges(item.concept, nodeIds)));
-
-  const edges = (await edgesPromises).reduce(collect, []);
+  const edges = (await Promise.all(data.filter(item => item.shouldVisualise).map(item => getInstanceEdges(item.concept, nodeIds)))).reduce(collect, []);
 
   return { nodes, edges };
 };
@@ -410,7 +407,7 @@ const buildTypes = async (answers) => {
 
   const nodes = await Promise.all(data.filter(item => item.shouldVisualise).map(item => getTypeNode(item.concept, item.graqlVar)));
   const nodeIds = nodes.map(node => node.id);
-  const edges = await Promise.all(data.filter(item => item.shouldVisualise).map(item => getTypeEdges(item.concept, nodeIds))).reduce(collect, []);
+  const edges = (await Promise.all(data.filter(item => item.shouldVisualise).map(item => getTypeEdges(item.concept, nodeIds)))).reduce(collect, []);
 
   return { nodes, edges };
 };


### PR DESCRIPTION
## What is the goal of this PR?
Previously, when constructing edges for a given node, all possible edges from that node were built regardless of whether the destination node was present in the visualiser. This is no longer the case and edges are only constructed between the given node and the nodes that are to be produced as a result of the given query.

## What are the changes implemented in this PR?
- passes the list of existing node ids to `getTypeEdges` and `getInstanceEdges` and excludes edges where both their `to` and `from` nodes are not present within the list of given node ids.
resolves #199 