### PR TITLE
Individual nodes are again draggable after shift + double-clicking on a node.

### DIFF
--- a/src/renderer/components/Visualiser/store/actions.js
+++ b/src/renderer/components/Visualiser/store/actions.js
@@ -186,7 +186,7 @@ export default {
     graknTx.close();
 
     if (data) { // when attributes are found, construct edges and add to graph
-      const edges = data.nodes.map(attr => ({ from: visNode.id, to: attr.id, label: 'has' }));
+      const edges = data.nodes.map(attr => CDB.getEdge(visNode, attr, CDB.edgeTypes.instance.HAS));
 
       state.visFacade.addToCanvas({ nodes: data.nodes, edges });
       commit('updateCanvasData');


### PR DESCRIPTION
## What is the goal of this PR?
As a result of a recent bug, the dragging behaviour would break when the rendered nodes were added to the visualiser by shift + double-clicking on a node (loading attributes). This unexpected behaviour has been fixed.

## What are the changes implemented in this PR?
- add missing properties to edges constructed as a result of shift + double-clicking on a node
