### PR TITLE
Visualises only the most granular role when loading roleplayers

### DIFF
--- a/src/renderer/components/shared/CanvasDataBuilder.js
+++ b/src/renderer/components/shared/CanvasDataBuilder.js
@@ -527,6 +527,7 @@ const buildRPInstances = async (answers, currentData, shouldLimit, graknTx) => {
         if (shouldLimit) queryToGetRPs += `limit ${QuerySettings.getNeighboursLimit()};`;
 
         const answers = await (await graknTx.query(queryToGetRPs)).collect();
+
         for (let k = 0; k < answers.length; k += 1) {
           const rolesAndRps = Array.from(answers[k].map().values());
           const role = rolesAndRps.filter(x => x.isRole())[0];

--- a/src/renderer/components/shared/CanvasDataBuilder.js
+++ b/src/renderer/components/shared/CanvasDataBuilder.js
@@ -523,11 +523,10 @@ const buildRPInstances = async (answers, currentData, shouldLimit, graknTx) => {
       const [graqlVar, instance] = answersGroup[j];
 
       if (instance.isRelation() && await shouldVisualiseInstance(instance)) {
-        let queryToGetRPs = `match $r id ${instance.id}; $r($rl: $rp); not { $rl type role; }; get $rp, $rl; offset 0; `;
+        let queryToGetRPs = `match $r id ${instance.id}; $r($rl: $rp); not { $b sub $rl; $b != $rl; }; get $rp, $rl; offset 0; `;
         if (shouldLimit) queryToGetRPs += `limit ${QuerySettings.getNeighboursLimit()};`;
 
         const answers = await (await graknTx.query(queryToGetRPs)).collect();
-
         for (let k = 0; k < answers.length; k += 1) {
           const rolesAndRps = Array.from(answers[k].map().values());
           const role = rolesAndRps.filter(x => x.isRole())[0];


### PR DESCRIPTION
## What is the goal of this PR?
When the `Load Roleplayers` is switched on in the Settings, the visualised role edges no longer include the roles that are played by the roleplayer indirectly (via role hierarchies). Instead, the only role edge that is visualised belongs to the most granular role played by that roleplayer. 

## What are the changes implemented in this PR?
- negates the roles that have a sub-role within the given relation
