### PR TITLE
Refer to Homebrew formula by full name

### DIFF
--- a/RELEASE_TEMPLATE.md
+++ b/RELEASE_TEMPLATE.md
@@ -7,8 +7,7 @@ Grakn Workbase is available for Linux, Mac and Windows (download binaries below)
 For Mac, Grakn Workbase also available through Brew Cask:
 ```
 brew tap graknlabs/tap
-brew tap-pin graknlabs/tap
-brew cask install grakn-workbase
+brew cask install graknlabs/tap/grakn-workbase
 ```
 
 { release notes }


### PR DESCRIPTION
## What is the goal of this PR?
Providing the correct installation instructions in the release template.

## What are the changes implemented in this PR?
When running `brew tap-pin graknlabs/tap` your action is declined and you get this message 
> "Warning: Calling brew tap-pin user/tap is deprecated! Use fully-scoped user/tap/formula naming instead."
The release template was updated to a working solution. 