### PR TITLE
Refactor how version is provided to deployment rules

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -210,7 +210,7 @@ jobs:
           command: |
             export DEPLOY_BREW_TOKEN=$REPO_GITHUB_TOKEN
             export DEPLOY_BREW_CHECKSUM=$(sha256sum grakn-workbase-mac-$(cat VERSION).dmg | awk '{print $1}')
-            bazel run //:deploy-brew -- release
+            bazel run --define version=$(cat VERSION) //:deploy-brew -- release
 
   release-cleanup:
     machine: true

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -24,5 +24,4 @@ deploy_brew(
     type = "cask",
     deployment_properties = "@graknlabs_build_tools//:deployment.properties",
     formula = "//config/brew:grakn-workbase.rb",
-    version_file = "//:VERSION"
 )


### PR DESCRIPTION
## What is the goal of this PR?

Adapt `@graknlabs_workbase` to latest changes in bazel-distribution (in particular, graknlabs/bazel-distribution#150)

## What are the changes implemented in this PR?

Instead of supplying `version_file` everywhere, use `--define version=<>` as a Bazel argument to supply version.

