### PR TITLE
Minor fix to text banner when running Workbase in developer mode

### DIFF
--- a/.electron-vue/dev-runner.js
+++ b/.electron-vue/dev-runner.js
@@ -160,11 +160,9 @@ function greeting () {
   const cols = process.stdout.columns
   let text = ''
 
-  if (cols > 104) text = 'GRAKN workbase'
-  else if (cols > 76) text = 'GRAKN|workbase'
-  else text = false
-
-  if (cols < 116) text = 'GRAKN|workbase'
+  text = false
+  if ((cols > 76) && (cols <= 115)) text = 'GRAKN|workbase'
+  else if (cols > 115) text = 'GRAKN workbase'
 
   if (text) {
     say(text, {

--- a/.electron-vue/dev-runner.js
+++ b/.electron-vue/dev-runner.js
@@ -164,6 +164,8 @@ function greeting () {
   else if (cols > 76) text = 'GRAKN|workbase'
   else text = false
 
+  if (cols < 116) text = 'GRAKN|workbase'
+
   if (text) {
     say(text, {
       colors: ['yellow'],


### PR DESCRIPTION
## What is the goal of this PR?

Checks if the screen has 115 or less columns, and if it does wordwraps the Grakn workbase text into two lines - looks neater, like the below:

```
yarn dev
yarn run v1.21.1
$ node .electron-vue/dev-runner.js
   __                        __  __
 / _ `\    _ __     __      /\ \/  \     ___
/\ \_\ \  /\` __\ /'__`\    \ \    <   /' _ `\
\ \____ \ \ \ \/ /\ \_\.\_   \ \  ^  \ /\ \/\ \
 \/___/\ \ \ \_\ \ \__/.\_\   \ \_\ \_\\ \_\ \_\
   /\____/  \/_/  \/__/\/_/    \/_/\/_/ \/_/\/_/
   \_/__/

                              __  __     __
 __  __  __    ___    _ __   /\ \/  \   /\ \         __       ____     __
/\ \/\ \/\ \  / __`\ /\` __\ \ \    <   \ \ \____  /'__`\    / ,__\  / ,.`\
\ \ \_/ \_/ \/\ \_\ \\ \ \/   \ \  ^  \  \ \  ,. \/\ \_\.\_ /\__, `\/\  __/
 \ \___^___/'\ \____/ \ \_\    \ \_\ \_\  \ \____/\ \__/.\_\\/\____/\ \____\
  \/__//__/   \/___/   \/_/     \/_/\/_/   \/___/  \/__/\/_/ \/___/  \/____/

  getting ready...
```

## What are the changes implemented in this PR?

Small change made to `.electron-vue/dev-runner.js` to check for screen width