### PR TITLE
Fix CI by upgrading Grakn Core and build-tools

### DIFF
--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -22,14 +22,14 @@ def graknlabs_build_tools():
     git_repository(
         name = "graknlabs_build_tools",
         remote = "https://github.com/graknlabs/build-tools",
-        commit = "2917a6d9348d67b036d762f521e6a8680101ea51", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
+        commit = "470ef85d8a87e4b60cf35b15ca2a6ed84c50f552", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
     )
 
 def graknlabs_grakn_core():
     git_repository(
         name = "graknlabs_grakn_core",
         remote = "https://github.com/graknlabs/grakn",
-        commit = "86f8a19a9bdac3093f5d131e0fe07667b047ca82", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
+        commit = "95ab6e9e0cbfa71322c917e0615534f36978b298", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
     )
 
 def graknlabs_client_nodejs():


### PR DESCRIPTION
## What is the goal of this PR?

Currently CI is broken on `master` due to old transitive dependency.

## What are the changes implemented in this PR?

Upgrade Grakn Core (such that Grakn Client Java is updated too) and `build-tools`