### PR TITLE
Improves performance of retrieving attributes and role players

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -24,7 +24,6 @@ linux:
   target: tar.gz
 mac:
   hardenedRuntime: true
-  # gatekeeperAssess: false
   artifactName: 'grakn-workbase-${version}-mac.${ext}'
   icon: assets/icons/icon.icns
   target: dmg

--- a/src/renderer/components/Visualiser/VisualiserUtils.js
+++ b/src/renderer/components/Visualiser/VisualiserUtils.js
@@ -41,8 +41,8 @@ export function limitQuery(query) {
 
 export async function computeAttributes(nodes, graknTx) {
   const concepts = await Promise.all(nodes.map(node => graknTx.getConcept(node.id)));
-  const attrIerators = await Promise.all(concepts.map(concept => concept.attributes()));
-  const attrGroups = await Promise.all(attrIerators.map(iter => iter.collect()));
+  const attrIters = await Promise.all(concepts.map(concept => concept.attributes()));
+  const attrGroups = await Promise.all(attrIters.map(iter => iter.collect()));
 
   return Promise.all(attrGroups.map(async (attrGroup, i) => {
     nodes[i].attributes = await Promise.all(attrGroup.map(attr => new Promise((resolve) => {

--- a/src/renderer/components/Visualiser/VisualiserUtils.js
+++ b/src/renderer/components/Visualiser/VisualiserUtils.js
@@ -39,6 +39,14 @@ export function limitQuery(query) {
   return limitedQuery;
 }
 
+/**
+ * for each node, retrieves the label and value for all the node's attributes and adds them to
+ * `attributes` property of the node. the `attributes` property of the node is read to list the
+ * attributes' label and value in the sidebar for the selected node.
+ * @param {*} nodes nodes that are currently visualised in the graph
+ * @param {*} graknTx
+ * @return array of node objects, where each object includes the `attributes` property
+ */
 export async function computeAttributes(nodes, graknTx) {
   const concepts = await Promise.all(nodes.map(node => graknTx.getConcept(node.id)));
   const attrIters = await Promise.all(concepts.map(concept => concept.attributes()));

--- a/src/renderer/components/Visualiser/store/actions.js
+++ b/src/renderer/components/Visualiser/store/actions.js
@@ -117,8 +117,10 @@ export default {
       validateQuery(query);
       commit('loadingQuery', true);
       const graknTx = global.graknTx[rootState.activeTab];
-      const result = await (await graknTx.query(query)).collect();
-
+      const t0 = performance.now();
+      const result = await (await graknTx.query('match $x isa gene-disease-association-order-2; get;  offset 0; limit 10;')).collect();
+      const t1 = performance.now();
+      console.log('graknTx.query: ', t1 - t0);
       if (!result.length) {
         commit('loadingQuery', false);
         return null;
@@ -138,16 +140,27 @@ export default {
         const shouldLoadRPs = QuerySettings.getRolePlayersStatus();
         const shouldLimit = true;
 
-        const instancesData = await CDB.buildInstances(result);
+        const t2 = performance.now();
+        const instancesData = await CDB.buildInstances(result, query);
+        const t3 = performance.now();
+        console.log('CDB.buildInstances: ', t3 - t2);
+
         nodes.push(...instancesData.nodes);
         edges.push(...instancesData.edges);
 
+        const t4 = performance.now();
         const typesData = await CDB.buildTypes(result);
+        const t5 = performance.now();
+        console.log('CDB.buildTypes: ', t5 - t4);
+
         nodes.push(...typesData.nodes);
         edges.push(...typesData.edges);
 
         if (shouldLoadRPs) {
+          const t6 = performance.now();
           const rpData = await CDB.buildRPInstances(result, { nodes, edges }, shouldLimit, graknTx);
+          const t7 = performance.now();
+          console.log('CDB.buildRPInstances: ', t7 - t6);
           nodes.push(...rpData.nodes);
           edges.push(...rpData.edges);
         }

--- a/src/renderer/components/Visualiser/store/actions.js
+++ b/src/renderer/components/Visualiser/store/actions.js
@@ -117,10 +117,7 @@ export default {
       validateQuery(query);
       commit('loadingQuery', true);
       const graknTx = global.graknTx[rootState.activeTab];
-      const t0 = performance.now();
-      const result = await (await graknTx.query('match $x isa gene-disease-association-order-2; get;  offset 0; limit 10;')).collect();
-      const t1 = performance.now();
-      console.log('graknTx.query: ', t1 - t0);
+      const result = await (await graknTx.query(query)).collect();
       if (!result.length) {
         commit('loadingQuery', false);
         return null;
@@ -140,27 +137,18 @@ export default {
         const shouldLoadRPs = QuerySettings.getRolePlayersStatus();
         const shouldLimit = true;
 
-        const t2 = performance.now();
         const instancesData = await CDB.buildInstances(result, query);
-        const t3 = performance.now();
-        console.log('CDB.buildInstances: ', t3 - t2);
 
         nodes.push(...instancesData.nodes);
         edges.push(...instancesData.edges);
 
-        const t4 = performance.now();
         const typesData = await CDB.buildTypes(result);
-        const t5 = performance.now();
-        console.log('CDB.buildTypes: ', t5 - t4);
 
         nodes.push(...typesData.nodes);
         edges.push(...typesData.edges);
 
         if (shouldLoadRPs) {
-          const t6 = performance.now();
           const rpData = await CDB.buildRPInstances(result, { nodes, edges }, shouldLimit, graknTx);
-          const t7 = performance.now();
-          console.log('CDB.buildRPInstances: ', t7 - t6);
           nodes.push(...rpData.nodes);
           edges.push(...rpData.edges);
         }

--- a/src/renderer/components/Visualiser/store/actions.js
+++ b/src/renderer/components/Visualiser/store/actions.js
@@ -138,12 +138,10 @@ export default {
         const shouldLimit = true;
 
         const instancesData = await CDB.buildInstances(result, query);
-
         nodes.push(...instancesData.nodes);
         edges.push(...instancesData.edges);
 
         const typesData = await CDB.buildTypes(result);
-
         nodes.push(...typesData.nodes);
         edges.push(...typesData.edges);
 

--- a/src/renderer/components/shared/CanvasDataBuilder.js
+++ b/src/renderer/components/shared/CanvasDataBuilder.js
@@ -524,17 +524,16 @@ const buildRPInstances = async (answers, currentData, shouldLimit, graknTx) => {
 
           promises.push(new Promise((resolve) => {
             relation.asRemote(graknTx).rolePlayersMap().then((rolePlayersMap) => {
-              Array.from(rolePlayersMap.entries()).forEach(([role, players], i) => {
-                if (shouldLimit) players.slice(0, QuerySettings.getNeighboursLimit());
-
+              let rpEntries = Array.from(rolePlayersMap.entries());
+              if (shouldLimit) rpEntries = rpEntries.slice(0, QuerySettings.getNeighboursLimit());
+              rpEntries.forEach(([role, players], i) => {
                 role.label().then((edgeLabel) => {
                   players.forEach((player) => {
                     player.type().then(type => type.label().then((playerLabel) => {
                       player.label = playerLabel;
                       edges.push(getEdge(relation, player, edgeTypes.instance.RELATES, edgeLabel));
                       nodes.push(getInstanceNode(player, graqlVar, answer.explanation, answer.queryPattern));
-
-                      if (i === rolePlayersMap.size - 1) resolve({ edges, nodes });
+                      if (i === rpEntries.length - 1) resolve({ edges, nodes });
                     }));
                   });
                 });

--- a/src/renderer/components/shared/CanvasDataBuilder.js
+++ b/src/renderer/components/shared/CanvasDataBuilder.js
@@ -511,52 +511,162 @@ const buildNeighbours = async (targetConcept, answers) => {
  * @param {*} shouldLimit whether or not the roleplayers should be limited. false, when called to buildRPInstances for explanations
  * @param {*} graknTx
  */
+// eslint-disable-next-line no-unused-vars
 const buildRPInstances = async (answers, currentData, shouldLimit, graknTx) => {
   let edges = [];
   const nodes = [];
 
-  for (let i = 0; i < answers.length; i += 1) {
-    const answer = answers[i];
-    const answersGroup = Array.from(answer.map().entries());
+  const data = answers.map((answer) => {
+    const { explanation, queryPattern } = answer;
+    const graqlVars = Array.from(answer.map().keys());
+    const relations = Array.from(answer.map().values()).filter(instance => instance.isRelation() && shouldVisualiseInstance(instance)).map((relation, i) => (
+      { instance: relation, graqlVar: graqlVars[i] }
+    ));
+    return {
+      relations,
+      explanation,
+      queryPattern,
+    };
+  });
+  console.log(data);
+  debugger;
 
-    for (let j = 0; j < answersGroup.length; j += 1) {
-      const [graqlVar, instance] = answersGroup[j];
-
-      if (instance.isRelation() && shouldVisualiseInstance(instance)) {
-        const relationSup = await instance.type().asRemote(graknTx).sup();
-        const isRelationSubtyped = await relationSup.label() !== 'relation';
-
-        let queryToGetRPs;
-        if (isRelationSubtyped) { // getting the most granular role
-          queryToGetRPs = `match $r id ${instance.id}; $r($rl: $rp); not { $b sub $rl; $b != $rl; }; get $rp, $rl; offset 0; `;
-        } else { // getting all roles except the role metatype
-          queryToGetRPs = `match $r id ${instance.id}; $r($rl: $rp); not { $rl type role; }; get $rp, $rl; offset 0; `;
-        }
-        if (shouldLimit) queryToGetRPs += `limit ${QuerySettings.getNeighboursLimit()};`;
-
-        const answers = await (await graknTx.query(queryToGetRPs)).collect();
-
-        for (let k = 0; k < answers.length; k += 1) {
-          const rolesAndRps = Array.from(answers[k].map().values());
-          const role = rolesAndRps.filter(x => x.isRole())[0];
-          const roleplayers = rolesAndRps.filter(x => !x.isRole());
-          const edgeLabel = role.label();
-
-          for (let l = 0; l < roleplayers.length; l += 1) {
-            const rp = roleplayers[l];
-            if (rp.isThing() && shouldVisualiseInstance(rp)) {
-              edges.push(getEdge(instance, rp, edgeTypes.instance.RELATES, edgeLabel));
-              nodes.push(getInstanceNode(rp, graqlVar, answer.explanation, answer.queryPattern));
-            }
-          }
+  // eslint-disable-next-line no-plusplus
+  for (let i = 0; i < data.length; i++) {
+    const answerData = data[i];
+    // eslint-disable-next-line no-plusplus
+    for (let j = 0; j < answerData.relations.length; j++) {
+      const relation = answerData.relations[j].instance;
+      const rolePlayersMap = await relation.asRemote(graknTx).rolePlayersMap();
+      // eslint-disable-next-line no-loop-func
+      for (let k = 0; k < rolePlayersMap.size; k += 1) {
+        debugger;
+        const [role, players] = Array.from(rolePlayersMap.entries())[k];
+        // eslint-disable-next-line no-unused-vars
+        const edgeLabel = await role.label();
+        // eslint-disable-next-line no-loop-func
+        for (let m = 0; m < players.length; m += 1) {
+          const player = players[m];
+          console.log('player: ', player);
+          player.label = await (await player.type()).label();
+          edges.push(getEdge(relation, player, edgeTypes.instance.RELATES, edgeLabel));
+          nodes.push(getInstanceNode(player, answerData.graqlVars, answerData.explanation, answerData.queryPattern));
+          debugger;
         }
       }
     }
   }
 
+  // const rolePlayersMaps = await Promise.all(data.map(item => item.relations).map(relation => relation.instance.asRemote(graknTx).rolePlayersMap()));
+  // debugger;
+
+  // rolePlayersMaps.forEach((map, i) => {
+  //   const roles = Array.from(map.keys());
+  //   data[i].roles = roles;
+
+  //   const players = Array.from(map.values()).reduce(collect, []);
+  //   data[i].players = players;
+  // });
+
+  // debugger;
+
+  // data.forEach((item) => {
+  //   item.roles.forEach((role, i) => {
+  //     item.players[i].type().then((type) => {
+  //       type.label().then((label) => {
+  //         item.players[i].label = label;
+  //         debugger;
+  //         edges.push(getEdge(item.relations[i], item.players[i], edgeTypes.instance.RELATES, role.label()));
+  //         nodes.push(getInstanceNode(item.players[i], item.graqlVars[i], item.explanation, item.queryPattern));
+  //       });
+  //     });
+  //   });
+  // });
+
+  // debugger;
+
+  // const relationsWithVars = answers.map(answer =>
+  //   Array.from(answer.map().entries()).filter(([, instance]) => instance.isRelation() && shouldVisualiseInstance(instance)),
+  // ).reduce(collect, []);
+  // console.log(relationsWithVars);
+  // debugger;
+
+  // const rolePlayersMaps = await Promise.all(relationsWithVars.map(([, relation]) => relation.asRemote(graknTx).rolePlayersMap()));
+  // console.log(rolePlayersMaps);
+  // debugger;
+
+  // Array.from(rolePlayersMaps.entries()).filter(([, player]) => shouldVisualiseInstance(player)).forEach(([role, player], i) => {
+  //   const edgeLabel = role.label();
+  //   edges.push(getEdge(relationsWithVars[i][1], rp, edgeTypes.instance.RELATES, edgeLabel));
+  //   nodes.push(getInstanceNode(player, relationsWithVars[i][0], answers.explanation, answer.queryPattern));
+  // });
+
+  // await Promise.all(answers.forEach((answer) => {
+  //   const relationMaps = Array.from(answer.map().entries()).filter(([, instance]) => instance.isRelation() && shouldVisualiseInstance(instance));
+  //   debugger;
+  //   return relationMaps.map(async ([graqlVar, relation]) => {
+  //     const rolePlayers = Array.from((await relation.rolePlayersMap()).entries());
+  //     console.log('rolePlayers', rolePlayers);
+  //     debugger;
+  //     return rolePlayers.map(async ([role, players]) => {
+  //       const edgeLabel = await role.label();
+  //       debugger;
+  //       return players.map(async (player) => {
+  //         player.label = await (await player.type()).label();
+  //         edges.push(getEdge(relation, player, edgeTypes.instance.RELATES, edgeLabel));
+  //         nodes.push(getInstanceNode(player, graqlVar, answer.explanation, answer.queryPattern));
+  //         debugger;
+  //       });
+  //     });
+  //   });
+  // }));
+
+  // for (let i = 0; i < answers.length; i += 1) {
+  //   const answer = answers[i];
+  //   const answersGroup = Array.from(answer.map().entries());
+
+  //   for (let j = 0; j < answersGroup.length; j += 1) {
+  //     const [graqlVar, instance] = answersGroup[j];
+
+  //     if (instance.isRelation() && shouldVisualiseInstance(instance)) {
+  //       const relationSup = await instance.type().asRemote(graknTx).sup();
+  //       const isRelationSubtyped = await relationSup.label() !== 'relation';
+
+  //       let queryToGetRPs;
+  //       if (isRelationSubtyped) { // getting the most granular role
+  //         queryToGetRPs = `match $r id ${instance.id}; $r($rl: $rp); not { $b sub $rl; $b != $rl; }; get $rp, $rl; offset 0; `;
+  //       } else { // getting all roles except the role metatype
+  //         queryToGetRPs = `match $r id ${instance.id}; $r($rl: $rp); not { $rl type role; }; get $rp, $rl; offset 0; `;
+  //       }
+  //       if (shouldLimit) queryToGetRPs += `limit ${QuerySettings.getNeighboursLimit()};`;
+
+  //       const t1 = performance.now();
+  //       console.log(queryToGetRPs);
+  //       const answers = await (await graknTx.query(queryToGetRPs)).collect();
+  //       const t2 = performance.now();
+  //       console.log('buildRPInstances: graknTx.query: ', t2 - t1);
+
+  //       for (let k = 0; k < answers.length; k += 1) {
+  //         const rolesAndRps = Array.from(answers[k].map().values());
+  //         const role = rolesAndRps.filter(x => x.isRole())[0];
+  //         const roleplayers = rolesAndRps.filter(x => !x.isRole());
+  //         const edgeLabel = role.label();
+
+  //         for (let l = 0; l < roleplayers.length; l += 1) {
+  //           const rp = roleplayers[l];
+  //           if (rp.isThing() && shouldVisualiseInstance(rp)) {
+  //             edges.push(getEdge(instance, rp, edgeTypes.instance.RELATES, edgeLabel));
+  //             nodes.push(getInstanceNode(rp, graqlVar, answer.explanation, answer.queryPattern));
+  //           }
+  //         }
+  //       }
+  //     }
+  //   }
+  // }
+
   // exclude any edges that have already been produced by this module (i.e. currentData)
   if (currentData) edges = edges.filter(nEdge => !currentData.edges.some(cEdge => cEdge.id === nEdge.id));
-
+  debugger;
   return { nodes, edges };
 };
 

--- a/test/e2e/QuerySettings.test.js
+++ b/test/e2e/QuerySettings.test.js
@@ -35,14 +35,14 @@ describe('Query Settings', () => {
 
   test('Neighbours Limit setting is applied', async () => {
     await selectKeyspace('gene', app);
-    await changeSetting({ loadRoleplayers: true, neighboursLimit: 2 }, app);
+    await changeSetting({ loadRoleplayers: true, neighboursLimit: 2, queryLimit: 1 }, app);
     await runQuery('match $x isa parentship; get;', app);
     assert.equal(await app.client.getText('.no-of-entities'), 'entities: 2');
   });
 
   test('Load Neighbours enabled is applied', async () => {
     await selectKeyspace('gene', app);
-    await changeSetting({ neighboursLimit: 1, loadRoleplayers: true }, app);
+    await changeSetting({ neighboursLimit: 1, loadRoleplayers: true, queryLimit: 1 }, app);
     await runQuery('match $x isa parentship; get;', app);
     assert.equal(await app.client.getText('.no-of-entities'), 'entities: 1');
   });

--- a/test/unit/components/Visualiser/VisualiserUtils.test.js
+++ b/test/unit/components/Visualiser/VisualiserUtils.test.js
@@ -96,7 +96,6 @@ describe('limit Query', () => {
 describe('Compute Attributes', () => {
   test('attach attributes to type', async () => {
     const attributeType = getMockedAttributeType({
-      isRemote: true,
       extraProps: {
         remote: {
           label: () => Promise.resolve('attribute-type'),
@@ -105,6 +104,7 @@ describe('Compute Attributes', () => {
     });
 
     const entityType = getMockedEntityType({
+      isRemote: true,
       extraProps: {
         remote: {
           attributes: () => Promise.resolve({ collect: () => Promise.resolve([attributeType.asRemote()]) }),
@@ -117,12 +117,10 @@ describe('Compute Attributes', () => {
       getConcept: () => Promise.resolve(entityType),
     });
 
-    computeAttributes([entityType], graknTx).then((nodes) => {
-      expect(nodes[0].attributes).toHaveLength(1);
-
-      const attrType = nodes[0].attributes[0];
-      expect(attrType.type).toBe('attribute-type');
-    });
+    const nodes = await computeAttributes([entityType], graknTx);
+    expect(nodes[0].attributes).toHaveLength(1);
+    const attrType = nodes[0].attributes[0];
+    expect(attrType.type).toBe('attribute-type');
   });
 
   test('attach attributes to thing', async () => {


### PR DESCRIPTION
## What is the goal of this PR?
Changes introduced in this PR are aimed at improving the performance of Workbase, by using the Concept API instead of constructing and running native Graql queries.

## What are the changes implemented in this PR?

### Attributed Retrieval
The post-processing step that occurs after visualising the graph for the user query, now uses the Concept API (instead of constructing and running a Graql query) to fetch the attributes of each node. Although this results in much faster retrieval of attributes, it does come with the limitation of missing inferred attributes. we will revert this change, once we have optimised the query planner for fast retrieval of attributes (of a given instance) through a Graql query.

### Fetching roleplayers (_Load Roleplayers_ enabled)
When the user enables the _Load Roleplayers_ option and queries for a relation, without specifying its roleplayers, prior to this PR Workbase would run a Graql query for each relation instance in order to fetch its roleplayers and visualise them. This now happens via the Concept API which results in a significant improvement in the query time.