### PR TITLE
Brings Grakn 1.8 Support

### DIFF
--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -29,12 +29,12 @@ def graknlabs_grakn_core():
     git_repository(
         name = "graknlabs_grakn_core",
         remote = "https://github.com/graknlabs/grakn",
-        tag = "1.7.2", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
+        commit = "ababa285be4d0d71a537d77d1990c4291da7c16e", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
     )
 
 def graknlabs_client_nodejs():
     git_repository(
         name = "graknlabs_client_nodejs",
         remote = "https://github.com/graknlabs/client-nodejs",
-        tag = "1.7.0", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_nodejs
+        commit = "b85668f7063b2313ed02ab35cd0922e67d1f9f4b", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_nodejs
     )

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
         "@blueprintjs/table": "^3.1.1",
         "codemirror": "^5.38.0",
         "electron-store": "^1.3.0",
-        "grakn-client": "1.7.0",
+        "grakn-client": "https://repo.grakn.ai/repository/npm-snapshot-group/grakn-client/-/grakn-client-0.0.0-b85668f7063b2313ed02ab35cd0922e67d1f9f4b.tgz",
         "grpc": "^1.18.0",
         "hex-to-hsl": "^1.0.2",
         "image-data-uri": "^1.1.1",

--- a/src/renderer/components/SchemaDesign/LeftBar/NewAttributePanel.vue
+++ b/src/renderer/components/SchemaDesign/LeftBar/NewAttributePanel.vue
@@ -375,7 +375,7 @@
         superTypes: [],
         superType: undefined,
         showDataTypeList: false,
-        valueTypes: ['string', 'long', 'double', 'boolean', 'date'],
+        valueTypes: ['string', 'long', 'double', 'boolean', 'datetime'],
         valueType: undefined,
         showSpinner: false,
         toggledAttributeTypes: [],

--- a/src/renderer/components/SchemaDesign/LeftBar/NewAttributePanel.vue
+++ b/src/renderer/components/SchemaDesign/LeftBar/NewAttributePanel.vue
@@ -24,12 +24,12 @@
         <div class="row">
           <div class="data-type-options">
             <div class="list-label">data type</div>
-            <div v-if="superType === 'attribute'" class="btn data-type-btn" :class="(showDataTypeList) ? 'type-list-shown' : ''" @click="toggleDataList"><div class="type-btn-text" >{{dataType}}</div><div class="type-btn-caret"><vue-icon className="vue-icon" icon="caret-down"></vue-icon></div></div>
-            <div v-else class="inherited-data-type">{{dataType}}</div>
+            <div v-if="superType === 'attribute'" class="btn data-type-btn" :class="(showDataTypeList) ? 'type-list-shown' : ''" @click="toggleDataList"><div class="type-btn-text" >{{valueType}}</div><div class="type-btn-caret"><vue-icon className="vue-icon" icon="caret-down"></vue-icon></div></div>
+            <div v-else class="inherited-data-type">{{valueType}}</div>
 
             <div class="data-type-list" v-show="showDataTypeList">
-                <ul v-for="type in dataTypes" :key=type>
-                    <li class="type-item" @click="selectDataType(type)" :class="[(type === dataType) ? 'type-item-selected' : '']">{{type}}</li>
+                <ul v-for="type in valueTypes" :key=type>
+                    <li class="type-item" @click="selectDataType(type)" :class="[(type === valueType) ? 'type-item-selected' : '']">{{type}}</li>
                 </ul>
             </div>
           </div> 
@@ -375,8 +375,8 @@
         superTypes: [],
         superType: undefined,
         showDataTypeList: false,
-        dataTypes: ['string', 'long', 'double', 'boolean', 'date'],
-        dataType: undefined,
+        valueTypes: ['string', 'long', 'double', 'boolean', 'date'],
+        valueType: undefined,
         showSpinner: false,
         toggledAttributeTypes: [],
         toggledRoleTypes: [],
@@ -415,7 +415,7 @@
         if (val !== 'attribute') { // if super type is not 'attribute' set data type of super type
           const graknTx = await this[OPEN_GRAKN_TX]();
           const attributeType = await graknTx.getSchemaConcept(val);
-          this.dataType = (await attributeType.dataType()).toLowerCase();
+          this.valueType = (await attributeType.valueType()).toLowerCase();
           this.showDataTypeList = false;
 
           const sup = await graknTx.getSchemaConcept(val);
@@ -423,7 +423,7 @@
           this.hasAttributes = this.hasAttributes.filter(x => !this.supAttributes.includes(x));
           graknTx.close();
         } else {
-          this.dataType = this.dataTypes[0];
+          this.valueType = this.valueTypes[0];
 
           this.hasAttributes = this.metaTypeInstances.attributes;
           this.supAttributes = [];
@@ -437,7 +437,7 @@
         } else {
           this.showSpinner = true;
           this[DEFINE_ATTRIBUTE_TYPE]({
-            attributeLabel: this.attributeLabel, superType: this.superType, dataType: this.dataType, attributeTypes: this.toggledAttributeTypes, roleTypes: this.toggledRoleTypes,
+            attributeLabel: this.attributeLabel, superType: this.superType, valueType: this.valueType, attributeTypes: this.toggledAttributeTypes, roleTypes: this.toggledRoleTypes,
           })
             .then(() => {
               this.showSpinner = false;
@@ -456,7 +456,7 @@
         this.showAttributeTypeList = false;
       },
       selectDataType(type) {
-        this.dataType = type;
+        this.valueType = type;
         this.showDataTypeList = false;
       },
       resetPanel() {
@@ -465,7 +465,7 @@
         this.showDataTypeList = false;
         this.superTypes = ['attribute', ...this.metaTypeInstances.attributes];
         this.superType = this.superTypes[0];
-        this.dataType = this.dataTypes[0];
+        this.valueType = this.valueTypes[0];
         this.toggledAttributeTypes = [];
         this.toggledRoleTypes = [];
         this.showHasPanel = false;

--- a/src/renderer/components/SchemaDesign/LeftBar/NewAttributePanel.vue
+++ b/src/renderer/components/SchemaDesign/LeftBar/NewAttributePanel.vue
@@ -303,10 +303,6 @@
     border: 1px solid var(--button-hover-border-color) !important;
   }
 
-  .override-datatype{
-    background-color: var(--gray-2) !important;
-  }
-
   .type-item {
     align-items: center;
     padding: 2px;

--- a/src/renderer/components/SchemaDesign/RightBar/ConceptInfoTab/AttributesPanel.vue
+++ b/src/renderer/components/SchemaDesign/RightBar/ConceptInfoTab/AttributesPanel.vue
@@ -12,7 +12,7 @@
 
                 <div v-for="(value, index) in attributes" :key="index">
                     <div class="content-item">
-                        <div class="label">{{value.type}}: {{value.dataType}}</div>
+                        <div class="label">{{value.type}}: {{value.valueType}}</div>
                         <div class="btn right-bar-btn reset-setting-btn" @click="removeAttributeType(value.type, index)"><vue-icon icon="trash" className="vue-icon" iconSize="12"></vue-icon></div>
                     </div>
                 </div>

--- a/src/renderer/components/SchemaDesign/SchemaHandler.js
+++ b/src/renderer/components/SchemaDesign/SchemaHandler.js
@@ -9,7 +9,7 @@ function SchemaHandler(graknTx) {
 function toGraknDatatype(valueTypeParam) {
   switch (valueTypeParam) {
     case 'string': return valueType.STRING;
-    case 'date': return valueType.DATE;
+    case 'datetime': return valueType.DATETIME;
     case 'boolean': return valueType.BOOLEAN;
     case 'long': return valueType.LONG;
     case 'double': return valueType.DOUBLE;

--- a/src/renderer/components/SchemaDesign/SchemaHandler.js
+++ b/src/renderer/components/SchemaDesign/SchemaHandler.js
@@ -1,4 +1,4 @@
-import { dataType } from 'grakn-client';
+import { valueType } from 'grakn-client';
 
 let tx;
 
@@ -6,14 +6,14 @@ function SchemaHandler(graknTx) {
   tx = graknTx;
 }
 
-function toGraknDatatype(dataTypeParam) {
-  switch (dataTypeParam) {
-    case 'string': return dataType.STRING;
-    case 'date': return dataType.DATE;
-    case 'boolean': return dataType.BOOLEAN;
-    case 'long': return dataType.LONG;
-    case 'double': return dataType.DOUBLE;
-    default: throw new Error(`Datatype not recognised. Received [${dataTypeParam}]`);
+function toGraknDatatype(valueTypeParam) {
+  switch (valueTypeParam) {
+    case 'string': return valueType.STRING;
+    case 'date': return valueType.DATE;
+    case 'boolean': return valueType.BOOLEAN;
+    case 'long': return valueType.LONG;
+    case 'double': return valueType.DOUBLE;
+    default: throw new Error(`Datatype not recognised. Received [${valueTypeParam}]`);
   }
 }
 
@@ -37,8 +37,8 @@ SchemaHandler.prototype.defineRelationType = async function define({ relationLab
   return type;
 };
 
-SchemaHandler.prototype.defineAttributeType = async function define({ attributeLabel, superType, dataType }) {
-  const type = await tx.putAttributeType(attributeLabel, toGraknDatatype(dataType));
+SchemaHandler.prototype.defineAttributeType = async function define({ attributeLabel, superType, valueType }) {
+  const type = await tx.putAttributeType(attributeLabel, toGraknDatatype(valueType));
   const directSuper = await tx.getSchemaConcept(superType);
   await type.sup(directSuper);
 };

--- a/src/renderer/components/SchemaDesign/SchemaUtils.js
+++ b/src/renderer/components/SchemaDesign/SchemaUtils.js
@@ -47,7 +47,7 @@ export async function computeAttributes(nodes, graknTx) {
   return Promise.all(nodes.map(async (node) => {
     const concept = await graknTx.getSchemaConcept(node.label);
     const attributes = await (await concept.attributes()).collect();
-    node.attributes = await Promise.all(attributes.map(async concept => ({ type: await concept.label(), dataType: await concept.dataType() })));
+    node.attributes = await Promise.all(attributes.map(async concept => ({ type: await concept.label(), valueType: await concept.valueType() })));
     return node;
   }));
 }

--- a/src/renderer/components/SchemaDesign/SchemaUtils.js
+++ b/src/renderer/components/SchemaDesign/SchemaUtils.js
@@ -27,7 +27,7 @@ export async function loadMetaTypeInstances(graknTx) {
     .then(labels => labels.filter(l => l !== 'entity')
       .concat()
       .sort());
-  metaTypeInstances.relations = await Promise.all(rels.map(async type => ((!await type.isImplicit()) ? type.label() : null)))
+  metaTypeInstances.relations = await Promise.all(rels.map(async type => type.label()))
     .then(labels => labels.filter(l => l && l !== 'relation')
       .concat()
       .sort());
@@ -35,7 +35,7 @@ export async function loadMetaTypeInstances(graknTx) {
     .then(labels => labels.filter(l => l !== 'attribute')
       .concat()
       .sort());
-  metaTypeInstances.roles = await Promise.all(roles.map(async type => ((!await type.isImplicit()) ? type.label() : null)))
+  metaTypeInstances.roles = await Promise.all(roles.map(async type => type.label()))
     .then(labels => labels.filter(l => l && l !== 'role')
       .concat()
       .sort());
@@ -57,7 +57,7 @@ export async function computeRoles(nodes, graknTx) {
   return Promise.all(nodes.map(async (node) => {
     const concept = await graknTx.getSchemaConcept(node.label);
     const roles = await (await concept.playing()).collect();
-    node.roles = await Promise.all(roles.map(async concept => ((await concept.isImplicit()) ? null : concept.label()))).then(nodes => nodes.filter(x => x));
+    node.roles = await Promise.all(roles.map(concept => concept.label())).then(nodes => nodes.filter(x => x));
     return node;
   }));
 }

--- a/src/renderer/components/Visualiser/TopBar/GraqlEditor/GraqlCodeMirror.js
+++ b/src/renderer/components/Visualiser/TopBar/GraqlEditor/GraqlCodeMirror.js
@@ -7,7 +7,7 @@ CodeMirror.defineSimpleMode('graql', {
   start: [
     { regex: /#.*/, token: 'comment' },
     { regex: /".*?"/, token: 'string' },
-    { regex: /(match|insert|delete|select|isa|sub|plays|relates|datatype|abstract|has|value|id|of|limit|offset|order|by|compute|from|to|in|aggregate|label|get|using|where)(?![-a-zA-Z_0-9])/, // eslint-disable-line max-len
+    { regex: /(match|insert|delete|select|isa|sub|plays|relates|value|abstract|has|value|id|of|limit|offset|order|by|compute|from|to|in|aggregate|label|get|using|where)(?![-a-zA-Z_0-9])/, // eslint-disable-line max-len
       token: 'keyword' },
     { regex: /true|false/, token: 'number' },
     { regex: /\$[-a-zA-Z_0-9]+/, token: 'variable' },

--- a/src/renderer/components/Visualiser/TopBar/GraqlEditor/GraqlCodeMirror.js
+++ b/src/renderer/components/Visualiser/TopBar/GraqlEditor/GraqlCodeMirror.js
@@ -7,7 +7,7 @@ CodeMirror.defineSimpleMode('graql', {
   start: [
     { regex: /#.*/, token: 'comment' },
     { regex: /".*?"/, token: 'string' },
-    { regex: /(match|insert|delete|select|isa|sub|plays|relates|value|abstract|has|value|id|of|limit|offset|order|by|compute|from|to|in|aggregate|label|get|using|where)(?![-a-zA-Z_0-9])/, // eslint-disable-line max-len
+    { regex: /(match|isa|isa!|sub|sub!|has|id|type|limit|offset|sort|asc|desc|get|compute|path|from|to)(?![-a-zA-Z_0-9])/, // eslint-disable-line max-len
       token: 'keyword' },
     { regex: /true|false/, token: 'number' },
     { regex: /\$[-a-zA-Z_0-9]+/, token: 'variable' },

--- a/src/renderer/components/Visualiser/VisualiserUtils.js
+++ b/src/renderer/components/Visualiser/VisualiserUtils.js
@@ -87,7 +87,7 @@ export async function loadMetaTypeInstances(graknTx) {
     .then(labels => labels.filter(l => l !== 'entity')
       .concat()
       .sort());
-  metaTypeInstances.relations = await Promise.all(rels.map(async type => ((!await type.isImplicit()) ? type.label() : null)))
+  metaTypeInstances.relations = await Promise.all(rels.map(type => type.label()))
     .then(labels => labels.filter(l => l && l !== 'relation')
       .concat()
       .sort());
@@ -95,7 +95,7 @@ export async function loadMetaTypeInstances(graknTx) {
     .then(labels => labels.filter(l => l !== 'attribute')
       .concat()
       .sort());
-  metaTypeInstances.roles = await Promise.all(roles.map(async type => ((!await type.isImplicit()) ? type.label() : null)))
+  metaTypeInstances.roles = await Promise.all(roles.map(type => type.label()))
     .then(labels => labels.filter(l => l && l !== 'role')
       .concat()
       .sort());
@@ -129,27 +129,6 @@ export function addResetGraphListener(dispatch, action) {
 }
 
 /**
- * Checks if a ConceptMap inside the provided Answer contains at least one implicit concept
- * @param {Object} answer ConceptMap Answer to be inspected
- * @return {Boolean}
- */
-async function answerContainsImplicitType(answer) {
-  const concepts = Array.from(answer.map().values());
-  return Promise.all(concepts.map(async concept => ((concept.isThing()) ? (await concept.type()).isImplicit() : concept.isImplicit())))
-    .then(a => a.includes(true));
-}
-
-/**
- * Filters out Answers that contained inferred concepts in their ConceptMap
- * @param {Object[]} answers array of ConceptMap Answers to be inspected
- * @return {Object[]} filtered array of Answers
- */
-export async function filterMaps(answers) { // Filter out ConceptMaps that contain implicit relations
-  return Promise.all(answers.map(async x => ((await answerContainsImplicitType(x)) ? null : x)))
-    .then(maps => maps.filter(map => map));
-}
-
-/**
  * Executes query to load neighbours of given node and filters our all the answers that contain implicit concepts, given that we
  * don't want to show implicit concepts (relations to attributes) to the user, for now.
  * @param {Object} node VisJs node of which we want to load the neighbours
@@ -159,11 +138,5 @@ export async function filterMaps(answers) { // Filter out ConceptMaps that conta
 export async function getFilteredNeighbourAnswers(node, graknTx, limit) {
   const query = getNeighboursQuery(node, limit);
   const resultAnswers = await (await graknTx.query(query)).collect();
-  const filteredResult = await filterMaps(resultAnswers);
-  if (resultAnswers.length !== filteredResult.length) {
-    const offsetDiff = resultAnswers.length - filteredResult.length;
-    node.offset += QuerySettings.getNeighboursLimit();
-    return filteredResult.concat(await getFilteredNeighbourAnswers(node, graknTx, offsetDiff));
-  }
   return resultAnswers;
 }

--- a/src/renderer/components/shared/CanvasDataBuilder.js
+++ b/src/renderer/components/shared/CanvasDataBuilder.js
@@ -40,17 +40,9 @@ const getConceptLabel = (concept) => {
   return label;
 };
 
-
-const shouldVisualiseInstance = (instance) => {
-  let shouldSkip = false;
-  if (instance.type().isImplicit()) shouldSkip = true;
-  return !shouldSkip;
-};
-
 const shouldVisualiseType = (type) => {
   let shouldSkip = false;
-  if (type.isImplicit()) shouldSkip = true;
-  else if (META_LABELS.has(getConceptLabel(type))) shouldSkip = true;
+  if (META_LABELS.has(getConceptLabel(type))) shouldSkip = true;
   return !shouldSkip;
 };
 
@@ -261,7 +253,7 @@ const buildInstances = async (answers) => {
     }));
   }).reduce(collect, []);
 
-  const shouldVisualiseVals = data.map(item => item.concept.isThing() && shouldVisualiseInstance(item.concept));
+  const shouldVisualiseVals = data.map(item => item.concept.isThing());
   data = data.map((item, index) => {
     item.shouldVisualise = shouldVisualiseVals[index];
     return item;
@@ -515,7 +507,7 @@ const buildNeighbours = async (targetConcept, answers) => {
     }));
   }).reduce(collect, []);
 
-  const shouldVisualiseVals = data.map(item => item.concept.isThing() && shouldVisualiseInstance(item.concept));
+  const shouldVisualiseVals = data.map(item => item.concept.isThing());
 
   data = data.map((item, index) => {
     item.shouldVisualise = shouldVisualiseVals[index];
@@ -562,7 +554,7 @@ const buildRPInstances = async (answers, currentData, shouldLimit, graknTx) => {
 
     answers.forEach((answer) => {
       Array.from(answer.map().entries()).forEach(([graqlVar, concept]) => {
-        if (concept.isRelation() && shouldVisualiseInstance(concept)) {
+        if (concept.isRelation()) {
           const relation = concept;
 
           promises.push(new Promise((resolve) => {

--- a/test/helpers/MockConcepts.js
+++ b/test/helpers/MockConcepts.js
@@ -36,7 +36,7 @@ function getMockAttributeType() {
     label: () => Promise.resolve('name'),
     isImplicit: () => Promise.resolve(false),
     isType: () => true,
-    dataType: () => Promise.resolve('String'),
+    valueType: () => Promise.resolve('String'),
   };
 }
 

--- a/test/helpers/MockConcepts.js
+++ b/test/helpers/MockConcepts.js
@@ -5,7 +5,6 @@ function getMockEntityType() {
     id: '0000',
     label: () => Promise.resolve('person'),
     instances: () => Promise.resolve({ next: () => Promise.resolve(getMockEntity1()) }), // eslint-disable-line no-use-before-define
-    isImplicit: () => Promise.resolve(false),
     attributes: () => Promise.resolve({ next: () => Promise.resolve(getMockAttributeType()), collect: () => Promise.resolve([getMockAttributeType()]) }), // eslint-disable-line no-use-before-define
     playing: () => Promise.resolve({ next: () => Promise.resolve(getMockRoleType1()), collect: () => Promise.resolve([getMockRoleType1(), getMockRoleType2()]) }), // eslint-disable-line no-use-before-define
     isType: () => true,
@@ -17,7 +16,6 @@ function getMockRoleType1() {
   return {
     baseType: 'Role_TYPE',
     label: () => Promise.resolve('child'),
-    isImplicit: () => Promise.resolve(false),
   };
 }
 
@@ -25,7 +23,6 @@ function getMockRoleType2() {
   return {
     baseType: '',
     label: () => Promise.resolve('@has'),
-    isImplicit: () => Promise.resolve(true),
   };
 }
 
@@ -34,7 +31,6 @@ function getMockAttributeType() {
     baseType: 'ATTRIBUTE_TYPE',
     id: '1111',
     label: () => Promise.resolve('name'),
-    isImplicit: () => Promise.resolve(false),
     isType: () => true,
     valueType: () => Promise.resolve('String'),
   };
@@ -45,7 +41,6 @@ function getMockRelationType() {
     baseType: 'RELATION_TYPE',
     id: '2222',
     label: () => Promise.resolve('parentship'),
-    isImplicit: () => Promise.resolve(false),
   };
 }
 
@@ -53,7 +48,6 @@ function getMockImplicitRelationType() {
   return {
     baseType: 'RELATION_TYPE',
     id: '2222',
-    isImplicit: () => Promise.resolve(true),
     isThing: () => false,
   };
 }

--- a/test/helpers/gene.gql
+++ b/test/helpers/gene.gql
@@ -27,8 +27,8 @@ surname sub attribute, datatype string;
 middlename sub attribute, datatype string;
 picture sub attribute, datatype string;
 age sub attribute, datatype long;
-birth-date sub attribute, datatype date;
-death-date sub attribute, datatype date;
+birth-date sub attribute, datatype datetime;
+death-date sub attribute, datatype datetime;
 gender sub attribute, datatype string;
 
 # Roles and Relations

--- a/test/helpers/gene.gql
+++ b/test/helpers/gene.gql
@@ -21,15 +21,15 @@ person sub entity,
 
 # Resources
 
-identifier sub attribute, datatype string;
-firstname sub attribute, datatype string;
-surname sub attribute, datatype string;
-middlename sub attribute, datatype string;
-picture sub attribute, datatype string;
-age sub attribute, datatype long;
-birth-date sub attribute, datatype datetime;
-death-date sub attribute, datatype datetime;
-gender sub attribute, datatype string;
+identifier sub attribute, value string;
+firstname sub attribute, value string;
+surname sub attribute, value string;
+middlename sub attribute, value string;
+picture sub attribute, value string;
+age sub attribute, value long;
+birth-date sub attribute, value datetime;
+death-date sub attribute, value datetime;
+gender sub attribute, value string;
 
 # Roles and Relations
 

--- a/test/helpers/mockedConcepts.js
+++ b/test/helpers/mockedConcepts.js
@@ -75,7 +75,7 @@ const methods = {
     },
     remote: {
       label: () => Promise.resolve('attribute-type'),
-      dataType: () => Promise.resolve('String'),
+      valueType: () => Promise.resolve('String'),
     },
   },
   relationType: {
@@ -122,11 +122,11 @@ const methods = {
       isEntity: () => true,
     },
     local: {
-      dataType: () => 'String',
+      valueType: () => 'String',
       value: () => 'attribute-value',
     },
     remote: {
-      dataType: () => Promise.resolve('String'),
+      valueType: () => Promise.resolve('String'),
       value: () => Promise.resolve('attribute-value'),
       owners: () => Promise.resolve({ collect: Promise.resolve([]) }),
     },
@@ -138,7 +138,7 @@ const methods = {
       isEntity: () => true,
     },
     local: {
-      dataType: () => 'String',
+      valueType: () => 'String',
       value: () => 'relation-value',
     },
     remote: {

--- a/test/helpers/mockedConcepts.js
+++ b/test/helpers/mockedConcepts.js
@@ -73,7 +73,7 @@ const methods = {
     },
     remote: {
       label: () => Promise.resolve('attribute-type'),
-      valueType: () => Promise.resolve('String'),
+      valueType: () => Promise.resolve('string'),
     },
   },
   relationType: {
@@ -120,11 +120,11 @@ const methods = {
       isEntity: () => true,
     },
     local: {
-      valueType: () => 'String',
+      valueType: () => 'string',
       value: () => 'attribute-value',
     },
     remote: {
-      valueType: () => Promise.resolve('String'),
+      valueType: () => Promise.resolve('string'),
       value: () => Promise.resolve('attribute-value'),
       owners: () => Promise.resolve({ collect: Promise.resolve([]) }),
     },
@@ -136,7 +136,7 @@ const methods = {
       isEntity: () => true,
     },
     local: {
-      valueType: () => 'String',
+      valueType: () => 'string',
       value: () => 'relation-value',
     },
     remote: {

--- a/test/helpers/mockedConcepts.js
+++ b/test/helpers/mockedConcepts.js
@@ -17,11 +17,9 @@ const methods = {
     },
     local: {
       label: () => 'thing',
-      isImplicit: () => false,
     },
     remote: {
       label: () => Promise.resolve('thing'),
-      isImplicit: () => Promise.resolve(false),
     },
   },
   type: {

--- a/test/integration/SchemaDesign/SchemaHandler.test.js
+++ b/test/integration/SchemaDesign/SchemaHandler.test.js
@@ -44,7 +44,7 @@ describe('Actions', () => {
     let graknTx = await graknSession.transaction().write();
     const schemaHandler = new SchemaHandler(graknTx);
 
-    await schemaHandler.defineAttributeType({ attributeLabel: 'name', dataType: 'string' });
+    await schemaHandler.defineAttributeType({ attributeLabel: 'name', valueType: 'string' });
     await graknTx.commit();
 
     graknTx = await graknSession.transaction().write();

--- a/test/unit/components/ScehmaDesign/SchemaUtils.test.js
+++ b/test/unit/components/ScehmaDesign/SchemaUtils.test.js
@@ -22,7 +22,7 @@ describe('Schema Utils', () => {
 
     const nodes = await computeAttributes([entityType], graknTx);
     expect(nodes[0].attributes[0].type).toBe('attribute-type');
-    expect(nodes[0].attributes[0].dataType).toBe('String');
+    expect(nodes[0].attributes[0].valueType).toBe('String');
   });
 
   test('Compute Roles', async () => {

--- a/test/unit/components/ScehmaDesign/SchemaUtils.test.js
+++ b/test/unit/components/ScehmaDesign/SchemaUtils.test.js
@@ -22,7 +22,7 @@ describe('Schema Utils', () => {
 
     const nodes = await computeAttributes([entityType], graknTx);
     expect(nodes[0].attributes[0].type).toBe('attribute-type');
-    expect(nodes[0].attributes[0].valueType).toBe('String');
+    expect(nodes[0].attributes[0].valueType).toBe('string');
   });
 
   test('Compute Roles', async () => {

--- a/test/unit/components/Visualiser/VisualiserUtils.test.js
+++ b/test/unit/components/Visualiser/VisualiserUtils.test.js
@@ -1,7 +1,6 @@
 import {
   limitQuery,
   computeAttributes,
-  filterMaps,
   validateQuery,
 } from '@/components/Visualiser/VisualiserUtils.js';
 
@@ -12,7 +11,6 @@ import {
   getMockedTransaction,
   getMockedEntity,
   getMockedAttribute,
-  getMockedRelation,
 } from '../../../helpers/mockedConcepts';
 
 Array.prototype.flatMap = function flat(lambda) { return Array.prototype.concat.apply([], this.map(lambda)); };
@@ -150,26 +148,6 @@ describe('Compute Attributes', () => {
 
     expect(nodes[0].attributes[0].type).toBe('attribute-type');
     expect(nodes[0].attributes[0].value).toBe('attribute-value');
-  });
-});
-
-describe('Filters out Answers that contain inferred concepts in their ConceptMap', () => {
-  test('contains implicit type', async () => {
-    const implicitRelation = getMockedRelation({ extraProps: { local: { isImplicit: () => true } } });
-    const nonImplicitRelation = getMockedRelation();
-
-    const answer = getMockedConceptMap([nonImplicitRelation, implicitRelation]);
-
-    const nonImplicitOnlyAnswer = await filterMaps([answer]);
-    expect(nonImplicitOnlyAnswer).toHaveLength(1);
-  });
-
-  test('does not contains implicit type', async () => {
-    const nonImplicitRelation = getMockedRelation();
-    const answer = getMockedConceptMap([nonImplicitRelation]);
-
-    const nonImplicitOnlyAnswer = await filterMaps([answer]);
-    expect(nonImplicitOnlyAnswer).toHaveLength(1);
   });
 });
 

--- a/test/unit/components/shared/CanvasDataBuilder.test.js
+++ b/test/unit/components/shared/CanvasDataBuilder.test.js
@@ -165,22 +165,6 @@ describe('building instances', () => {
     const explAnswers = await nodes[0].explanation().getAnswers();
     expect(explAnswers[0].map().get(0)).toEqual(explConcept);
   });
-
-  test('when graql answer contains an implicit instance', async () => {
-    const attribute = getMockedAttribute({
-      extraProps: {
-        local: {
-          type: () => getMockedAttributeType({
-            extraProps: { local: { isImplicit: () => true } },
-          }),
-        },
-      },
-    });
-    const answer = getMockedConceptMap([attribute]);
-    const { nodes, edges } = await CDB.buildInstances([answer]);
-    expect(nodes).toHaveLength(0);
-    expect(edges).toHaveLength(0);
-  });
 });
 
 describe('building types', () => {
@@ -406,21 +390,6 @@ describe('building types', () => {
     const answer = getMockedConceptMap([metaType]);
 
     const { nodes, edges } = await CDB.buildTypes([answer]);
-    expect(nodes).toHaveLength(0);
-    expect(edges).toHaveLength(0);
-  });
-
-  test('when graql answer contains an implicit type', async () => {
-    const relationType = getMockedRelationType({
-      extraProps: {
-        local: { isImplicit: () => true },
-      },
-    });
-
-    const answer = getMockedConceptMap([relationType]);
-
-    const { nodes, edges } = await CDB.buildTypes([answer]);
-
     expect(nodes).toHaveLength(0);
     expect(edges).toHaveLength(0);
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5077,10 +5077,9 @@ graceful-fs@^4.1.0, graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6,
   resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
   integrity sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=
 
-grakn-client@1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/grakn-client/-/grakn-client-1.7.0.tgz#7da5e4c27a075885ddae0eb4553ebc256c3ea601"
-  integrity sha512-ATtb8kj2Zn0ZxFl5TtLyf+XeckUqhUWBQ73CEhYid8VtA6CX/FfaSl2uQSVJW8h+x7kB18lYWPAtXUcacrkxAw==
+"grakn-client@https://repo.grakn.ai/repository/npm-snapshot-group/grakn-client/-/grakn-client-0.0.0-b85668f7063b2313ed02ab35cd0922e67d1f9f4b.tgz":
+  version "0.0.0-b85668f7063b2313ed02ab35cd0922e67d1f9f4b"
+  resolved "https://repo.grakn.ai/repository/npm-snapshot-group/grakn-client/-/grakn-client-0.0.0-b85668f7063b2313ed02ab35cd0922e67d1f9f4b.tgz#e65d8083c649ac4d2f25237958113ed1dbe4f9a8"
   dependencies:
     google-protobuf "^3.6.0"
     grpc "^1.24.1"


### PR DESCRIPTION
## What is the goal of this PR?
This PR brings the Grakn 1.8 support to Workbase.

## What are the changes implemented in this PR?
resolves https://github.com/graknlabs/workbase/issues/290

Following https://github.com/graknlabs/client-nodejs/commit/b85668f7063b2313ed02ab35cd0922e67d1f9f4b

- `dataType` to `valueType`
- `datatype` to `value`
- `date` to `datetime`
- removing all references to `isImplicit`
- bump `client-nodejs` and `grakn-core` dependencies