### PR TITLE
Resolves various bugs in the Schema Designer

### DIFF
--- a/src/renderer/components/SchemaDesign/LeftBar/NewRulePanel.vue
+++ b/src/renderer/components/SchemaDesign/LeftBar/NewRulePanel.vue
@@ -137,7 +137,7 @@
         } else {
           this.showSpinner = true;
 
-          this[DEFINE_RULE]({ ruleLabel: this.ruleLabel, when: `{${this.when}}`, then: `{${this.then}}` })
+          this[DEFINE_RULE]({ ruleLabel: this.ruleLabel, when: `{${this.when}};`, then: `{${this.then}};` })
             .then(() => {
               this.showSpinner = false;
               this.$notifyInfo(`Rule, ${this.ruleLabel}, has been defined`);

--- a/src/renderer/components/SchemaDesign/store/actions.js
+++ b/src/renderer/components/SchemaDesign/store/actions.js
@@ -136,7 +136,7 @@ export default {
 
     // attach attributes and roles to visnode and update on graph to render the right bar attributes
     let nodes = await computeAttributes([node], graknTx);
-    nodes = await computeRoles(nodes);
+    nodes = await computeRoles(nodes, graknTx);
     state.visFacade.updateNode(nodes);
     graknTx.close();
   },
@@ -177,7 +177,7 @@ export default {
 
     // attach attributes and roles to visnode and update on graph to render the right bar attributes
     let nodes = await computeAttributes([node], graknTx);
-    nodes = await computeRoles(nodes);
+    nodes = await computeRoles(nodes, graknTx);
     state.visFacade.updateNode(nodes);
     graknTx.close();
   },
@@ -353,7 +353,7 @@ export default {
 
     // attach attributes and roles to visnode and update on graph to render the right bar attributes
     nodes = await computeAttributes(nodes, graknTx);
-    nodes = await computeRoles(nodes);
+    nodes = await computeRoles(nodes, graknTx);
     state.visFacade.updateNode(nodes);
     graknTx.close();
   },

--- a/src/renderer/components/shared/CanvasDataBuilder.js
+++ b/src/renderer/components/shared/CanvasDataBuilder.js
@@ -407,17 +407,6 @@ const getTypeEdges = async (type, existingNodeIds) => {
 };
 
 /**
- * produces and returns nodes and edges for the given concept type
- * @param {Concept} type guaranteed to be a concept type
- * @param {String} graqlVar the Graql variable (as written in the original query) which holds the concept
- */
-const buildType = async (type, graqlVar = '') => {
-  const node = getTypeNode(type, graqlVar);
-  const edges = await getTypeEdges(type, [node.id]);
-  return { node, edges };
-};
-
-/**
  * produces and returns nodes and edges for the given answers
  * only the types stored within the answers are processed
  * @param {ConceptMap[]} answers the untouched response of a transaction.query()
@@ -616,12 +605,9 @@ const buildRPInstances = async (answers, currentData, shouldLimit, graknTx) => {
 export default {
   buildInstances,
   buildTypes,
-  buildType,
   buildRPInstances,
+  getTypeNode,
   getTypeEdges,
-  getTypeSubEdge,
-  getTypeRelatesEdges,
-  getTypeAttributeEdges,
   buildNeighbours,
   updateNodesLabel,
   // ideally the following functions should be private functions


### PR DESCRIPTION
## What is the goal of this PR?
Changes introduced in this PR, ensure that 
- no error is displayed upon defining a new type
- defining a new type with role and attribute associations visualise nodes and edges as expected
- undefining a type succeeds as expected
- defining a rule succeeds as expected

## What are the changes implemented in this PR?
resolves https://github.com/graknlabs/workbase/issues/280
resolves https://github.com/graknlabs/workbase/issues/294
resolves https://github.com/graknlabs/workbase/issues/272

### `CanvasDataBuilder`: reduced API
the two methods of the CDB APIs (`getTypeNode` and `getTypeEdges`) are now sufficient for constructing nodes and edges in the Schema Designer.