### PR TITLE
Displays an error message when running a multiline unsupported query

### DIFF
--- a/src/renderer/components/Visualiser/VisualiserUtils.js
+++ b/src/renderer/components/Visualiser/VisualiserUtils.js
@@ -106,15 +106,15 @@ export function validateQuery(query) {
   const trimmedQuery = query.trim();
   if (
     /^insert/.test(trimmedQuery)
-    || /^(.*;)\s*(insert\b.*;)$/.test(trimmedQuery)
-    || /^(.*;)\s*(delete\b.*;)$/.test(trimmedQuery)
-    || /^(.*;)\s*(count\b.*;)$/.test(trimmedQuery)
-    || /^(.*;)\s*(sum\b.*;)$/.test(trimmedQuery)
-    || /^(.*;)\s*(max\b.*;)$/.test(trimmedQuery)
-    || /^(.*;)\s*(min\b.*;)$/.test(trimmedQuery)
-    || /^(.*;)\s*(mean\b.*;)$/.test(trimmedQuery)
-    || /^(.*;)\s*(median\b.*;)$/.test(trimmedQuery)
-    || /^(.*;)\s*(group\b.*;)$/.test(trimmedQuery)
+    || /^((.|\n)*)(insert\b.*;)$/.test(trimmedQuery)
+    || /^((.|\n)*)(delete\b.*;)$/.test(trimmedQuery)
+    || /^((.|\n)*)(count\b.*;)$/.test(trimmedQuery)
+    || /^((.|\n)*)(sum\b.*;)$/.test(trimmedQuery)
+    || /^((.|\n)*)(max\b.*;)$/.test(trimmedQuery)
+    || /^((.|\n)*)(min\b.*;)$/.test(trimmedQuery)
+    || /^((.|\n)*)(mean\b.*;)$/.test(trimmedQuery)
+    || /^((.|\n)*)(median\b.*;)$/.test(trimmedQuery)
+    || /^((.|\n)*)(group\b.*;)$/.test(trimmedQuery)
     || (/^compute/.test(trimmedQuery) && !(/^compute path/.test(trimmedQuery)))
   ) {
     throw new Error('Only match get and compute path queries are supported by workbase for now.');

--- a/src/renderer/components/Visualiser/VisualiserUtils.js
+++ b/src/renderer/components/Visualiser/VisualiserUtils.js
@@ -117,7 +117,7 @@ export function validateQuery(query) {
     || /^((.|\n)*)(group\b.*;)$/.test(trimmedQuery)
     || (/^compute/.test(trimmedQuery) && !(/^compute path/.test(trimmedQuery)))
   ) {
-    throw new Error('Only match get and compute path queries are supported by workbase for now.');
+    throw new Error('At the moment, only `match get` and `compute path` queries are supported.');
   }
 }
 

--- a/test/unit/components/Visualiser/VisualiserUtils.test.js
+++ b/test/unit/components/Visualiser/VisualiserUtils.test.js
@@ -154,86 +154,100 @@ describe('Compute Attributes', () => {
 describe('Validate Query', () => {
   test('match get', async () => {
     const query = 'match $p isa person; get;';
-    expect(() => {
-      validateQuery(query);
-    }).not.toThrow();
+    expect(() => { validateQuery(query); }).not.toThrow();
+
+    const multilineQuery = 'match\n$p isa person;\nget;';
+    expect(() => { validateQuery(multilineQuery); }).not.toThrow();
   });
   test('compute path', async () => {
     const query = 'compute path from V229424, to V446496;';
-    expect(() => {
-      validateQuery(query);
-    }).not.toThrow();
+    expect(() => { validateQuery(query); }).not.toThrow();
+
+    const multilineQuery = 'compute path\nfrom V229424,\nto V446496;';
+    expect(() => { validateQuery(multilineQuery); }).not.toThrow();
   });
   test('insert', async () => {
     const query = 'insert $x isa emotion; $x "like";';
-    expect(() => {
-      validateQuery(query);
-    }).toThrow();
+    expect(() => { validateQuery(query); }).toThrow();
+
+    const multilineQuery = 'insert\n$x isa emotion; $x "like";';
+    expect(() => { validateQuery(multilineQuery); }).toThrow();
   });
   test('match insert', async () => {
     const query = 'match $x ias person, has name "John"; $y isa person, has name "Mary"; insert $r (child: $x, parent: $y) isa parentship;';
-    expect(() => {
-      validateQuery(query);
-    }).toThrow();
+    expect(() => { validateQuery(query); }).toThrow();
+
+    const multilineQuery = 'match\n$x ias person, has name "John";\n$y isa person, has name "Mary";\ninsert $r (child: $x, parent: $y) isa parentship;';
+    expect(() => { validateQuery(multilineQuery); }).toThrow();
   });
   test('match delete', async () => {
     const query = 'match $p isa person, has email "raphael.santos@gmail.com"; delete $p;';
-    expect(() => {
-      validateQuery(query);
-    }).toThrow();
+    expect(() => { validateQuery(query); }).toThrow();
+
+    const multilineQuery = 'match\n$p isa person, has email "raphael.santos@gmail.com";\ndelete $p;';
+    expect(() => { validateQuery(multilineQuery); }).toThrow();
   });
   test('count', async () => {
     const query = 'match $sce isa school-course-enrollment, has score $sco; $sco > 7.0; get; count;';
-    expect(() => {
-      validateQuery(query);
-    }).toThrow();
+    expect(() => { validateQuery(query); }).toThrow();
+
+    const multilineQuery = 'match\n$sce isa school-course-enrollment, has score $sco; $sco > 7.0;\nget; count;';
+    expect(() => { validateQuery(multilineQuery); }).toThrow();
   });
   test('sum', async () => {
     const query = 'match $org isa organisation, has name $orn; $orn "Medicely"; ($org) isa employment, has salary $sal; get $sal; sum $sal;';
-    expect(() => {
-      validateQuery(query);
-    }).toThrow();
+    expect(() => { validateQuery(query); }).toThrow();
+
+    const multilineQuery = 'match\n$org isa organisation, has name $orn; $orn "Medicely"; ($org) isa employment, has salary $sal;\nget $sal; sum $sal;';
+    expect(() => { validateQuery(multilineQuery); }).toThrow();
   });
   test('max', async () => {
     const query = 'match $sch isa school, has ranking $ran; get $ran; max $ran;';
-    expect(() => {
-      validateQuery(query);
-    }).toThrow();
+    expect(() => { validateQuery(query); }).toThrow();
+
+    const multilineQuery = 'match\n$sch isa school, has ranking $ran;\nget $ran; max $ran;';
+    expect(() => { validateQuery(multilineQuery); }).toThrow();
   });
   test('min', async () => {
     const query = 'match ($per) isa marriage; ($per) isa employment, has salary $sal; get $sal; min $sal;';
-    expect(() => {
-      validateQuery(query);
-    }).toThrow();
+    expect(() => { validateQuery(query); }).toThrow();
+
+    const multilineQuery = 'match\n($per) isa marriage; ($per) isa employment, has salary $sal;\nget $sal; min $sal;';
+    expect(() => { validateQuery(multilineQuery); }).toThrow();
   });
   test('mean', async () => {
     const query = 'match $emp isa employment, has salary $sal; get $sal; mean $sal;';
-    expect(() => {
-      validateQuery(query);
-    }).toThrow();
+    expect(() => { validateQuery(query); }).toThrow();
+
+    const multilineQuery = 'match\n$emp isa employment, has salary $sal;\nget $sal; mean $sal;';
+    expect(() => { validateQuery(multilineQuery); }).toThrow();
   });
   test('median', async () => {
     const query = 'match ($per) isa school-course-enrollment, has score $sco; get $sco; median $sco;';
-    expect(() => {
-      validateQuery(query);
-    }).toThrow();
+    expect(() => { validateQuery(query); }).toThrow();
+
+    const multilineQuery = 'match\n($per) isa school-course-enrollment, has score $sco;\nget $sco; median $sco;';
+    expect(() => { validateQuery(multilineQuery); }).toThrow();
   });
   test('group', async () => {
     const query = 'match $per isa person; $scc isa school-course, has title $tit; (student: $per, enrolled-course: $scc) isa school-course-enrollment; get; group $tit;';
-    expect(() => {
-      validateQuery(query);
-    }).toThrow();
+    expect(() => { validateQuery(query); }).toThrow();
+
+    const multilineQuery = 'match\n$per isa person; $scc isa school-course, has title $tit; (student: $per, enrolled-course: $scc) isa school-course-enrollment;\nget; group $tit;';
+    expect(() => { validateQuery(multilineQuery); }).toThrow();
   });
   test('group count', async () => {
     const query = 'match $per isa person; $scc isa school-course, has title $tit; (student: $per, enrolled-course: $scc) isa school-course-enrollment; get; group $tit; count;';
-    expect(() => {
-      validateQuery(query);
-    }).toThrow();
+    expect(() => { validateQuery(query); }).toThrow();
+
+    const multilineQuery = 'match\n$per isa person; $scc isa school-course, has title $tit;\nget; group $tit; count;';
+    expect(() => { validateQuery(multilineQuery); }).toThrow();
   });
   test('compute', async () => {
     const query = 'compute count in person;';
-    expect(() => {
-      validateQuery(query);
-    }).toThrow();
+    expect(() => { validateQuery(query); }).toThrow();
+
+    const multilineQuery = 'compute count in person;';
+    expect(() => { validateQuery(multilineQuery); }).toThrow();
   });
 });


### PR DESCRIPTION
## What is the goal of this PR?
Considering that Workbase, at the moment, only supports `match get` and `compute path` queries, when the user attempts to run an unsupported multiline query, they are presented with an informative error message. This change takes into account multiline queries in the query validation step.

## What are the changes implemented in this PR?
resolves https://github.com/graknlabs/workbase/issues/265
