### PR TITLE
Removes extra scrolling space from the Graql Editor

### DIFF
--- a/src/renderer/components/Visualiser/TopBar/GraqlEditor/GraqlEditor.vue
+++ b/src/renderer/components/Visualiser/TopBar/GraqlEditor/GraqlEditor.vue
@@ -252,11 +252,6 @@ export default {
 
       this.initialEditorHeight = $('.CodeMirror').height();
 
-      // for some reason, CodeMirror adds an anonymous <div> inside the auto generated .CodeMirror-scroll element.
-      // this <div> has a height of 50px (!) which distorts the GraqlEditor by allowing scroll when it shouldn't
-      // we're setting this height of this seeminly useless <div> to 0
-      document.getElementsByClassName('CodeMirror-scroll')[0].children[1].style.height = 0;
-
       this.codeMirror.on('change', (codeMirrorObj) => {
         this.setCurrentQuery(codeMirrorObj.getValue());
         this.editorLinesNumber = codeMirrorObj.lineCount();

--- a/src/renderer/components/Visualiser/TopBar/GraqlEditor/GraqlEditor.vue
+++ b/src/renderer/components/Visualiser/TopBar/GraqlEditor/GraqlEditor.vue
@@ -60,7 +60,6 @@
 </template>
 
 <style scoped>
-
     .editor-tooltip {
         top: 42px;
         left: -30px;
@@ -253,10 +252,16 @@ export default {
 
       this.initialEditorHeight = $('.CodeMirror').height();
 
+      // for some reason, CodeMirror adds an anonymous <div> inside the auto generated .CodeMirror-scroll element.
+      // this <div> has a height of 50px (!) which distorts the GraqlEditor by allowing scroll when it shouldn't
+      // we're setting this height of this seeminly useless <div> to 0
+      document.getElementsByClassName('CodeMirror-scroll')[0].children[1].style.height = 0;
+
       this.codeMirror.on('change', (codeMirrorObj) => {
         this.setCurrentQuery(codeMirrorObj.getValue());
         this.editorLinesNumber = codeMirrorObj.lineCount();
       });
+
       this.codeMirror.on('focus', () => {
         if (this.editorMinimized) this.maximizeEditor();
       });

--- a/static/styles/style.css
+++ b/static/styles/style.css
@@ -370,6 +370,15 @@ input::-webkit-inner-spin-button {
   justify-content: center;
 }
 
+/* code mirror */
+
+/* for some reason, CodeMirror adds an anonymous <div> inside the auto generated .CodeMirror-scroll element.
+this <div> has a height of 50px (!) which distorts the GraqlEditor by allowing scroll when it shouldn't.
+we're setting this height of this seeminly useless <div> to 0 */
+.CodeMirror-sizer + div {
+  height: 0 !important;
+}
+
 /* fav queries */
 
 .fav-query-center *{


### PR DESCRIPTION
## What is the goal of this PR?
The Graql Editor no longer contains blank lines which otherwise, would make the editor scrollable even with a single-line query.

## What are the changes implemented in this PR?
resolves https://github.com/graknlabs/workbase/issues/307