### PR TITLE
Retains lines of a multiline query when starring or applying a starred query

### DIFF
--- a/src/renderer/components/Visualiser/TopBar/FavQueries/FavQueriesList.vue
+++ b/src/renderer/components/Visualiser/TopBar/FavQueries/FavQueriesList.vue
@@ -123,6 +123,7 @@
         position: relative;
         display: flex;
         flex-direction: row;
+        overflow: scroll;
     }
 
 
@@ -188,6 +189,10 @@
             const cm = GraqlCodeMirror.getCodeMirror(queryInput);
             cm.setValue(this.favQueries[parseInt(queryInput.value, 10)].value);
             cm.setOption('readOnly', 'nocursor');
+            // for some reason, CodeMirror adds an anonymous <div> inside the auto generated .CodeMirror-scroll element.
+            // this <div> has a height of 50px (!) which distorts the GraqlEditor by allowing scroll when it shouldn't
+            // we're setting the height of this seemingly useless <div> to 0
+            queryInput.nextElementSibling.getElementsByClassName('CodeMirror-scroll')[0].children[1].style.height = 0;
             this.codeMirror.push(cm);
           }
         });

--- a/src/renderer/components/Visualiser/TopBar/FavQueries/FavQueriesList.vue
+++ b/src/renderer/components/Visualiser/TopBar/FavQueries/FavQueriesList.vue
@@ -189,10 +189,6 @@
             const cm = GraqlCodeMirror.getCodeMirror(queryInput);
             cm.setValue(this.favQueries[parseInt(queryInput.value, 10)].value);
             cm.setOption('readOnly', 'nocursor');
-            // for some reason, CodeMirror adds an anonymous <div> inside the auto generated .CodeMirror-scroll element.
-            // this <div> has a height of 50px (!) which distorts the GraqlEditor by allowing scroll when it shouldn't
-            // we're setting the height of this seemingly useless <div> to 0
-            queryInput.nextElementSibling.getElementsByClassName('CodeMirror-scroll')[0].children[1].style.height = 0;
             this.codeMirror.push(cm);
           }
         });

--- a/src/renderer/components/Visualiser/TopBar/GraqlEditor/GraqlEditor.vue
+++ b/src/renderer/components/Visualiser/TopBar/GraqlEditor/GraqlEditor.vue
@@ -60,7 +60,6 @@
 </template>
 
 <style scoped>
-
     .editor-tooltip {
         top: 42px;
         left: -30px;
@@ -253,10 +252,16 @@ export default {
 
       this.initialEditorHeight = $('.CodeMirror').height();
 
+      // for some reason, CodeMirror adds an anonymous <div> inside the auto generated .CodeMirror-scroll element.
+      // this <div> has a height of 50px (!) which distorts the GraqlEditor by allowing scroll when it shouldn't
+      // we're setting this height of this seeminly useless <div> to 0
+      document.getElementsByClassName('CodeMirror-scroll')[0].children[1].style.height = 0;
+
       this.codeMirror.on('change', (codeMirrorObj) => {
         this.setCurrentQuery(codeMirrorObj.getValue());
         this.editorLinesNumber = codeMirrorObj.lineCount();
       });
+
       this.codeMirror.on('focus', () => {
         if (this.editorMinimized) this.maximizeEditor();
       });

--- a/src/renderer/components/Visualiser/TopBar/GraqlEditor/GraqlEditor.vue
+++ b/src/renderer/components/Visualiser/TopBar/GraqlEditor/GraqlEditor.vue
@@ -254,7 +254,7 @@ export default {
 
       // for some reason, CodeMirror adds an anonymous <div> inside the auto generated .CodeMirror-scroll element.
       // this <div> has a height of 50px (!) which distorts the GraqlEditor by allowing scroll when it shouldn't
-      // we're setting this height of this seeminly useless <div> to 0
+      // we're setting the height of this seemingly useless <div> to 0
       document.getElementsByClassName('CodeMirror-scroll')[0].children[1].style.height = 0;
 
       this.codeMirror.on('change', (codeMirrorObj) => {
@@ -331,7 +331,7 @@ export default {
     objectToArray(object) {
       return Object.keys(object).map(key => ({
         name: key,
-        value: object[key].replace('\n', ''),
+        value: object[key],
       }));
     },
     minimizeEditor() {

--- a/static/styles/style.css
+++ b/static/styles/style.css
@@ -370,6 +370,15 @@ input::-webkit-inner-spin-button {
   justify-content: center;
 }
 
+/* code mirror */
+
+/* for some reason, CodeMirror adds an anonymous <div> inside the auto generated .CodeMirror-scroll element.
+this <div> has a height of 50px (!) which distorts the GraqlEditor by allowing scroll when it shouldn't.
+we're setting this height of this seeminly useless <div> to 0 */
+.CodeMirror-sizer + div {
+  height: 0 !important;
+}
+
 /* fav queries */
 
 .fav-query-center *{


### PR DESCRIPTION
## What is the goal of this PR?
Multiline queries no longer lose their lines when being starred or applied as a starred query.

## What are the changes implemented in this PR?
resolves https://github.com/graknlabs/workbase/issues/37
