### PR TITLE
Fixes automatic extension of user's query with the `limit` and `offset` modifiers

### DIFF
--- a/src/renderer/components/Visualiser/VisualiserUtils.js
+++ b/src/renderer/components/Visualiser/VisualiserUtils.js
@@ -2,7 +2,7 @@ import QuerySettings from './RightBar/SettingsTab/QuerySettings';
 const LETTER_G_KEYCODE = 71;
 
 export function limitQuery(query) {
-  const getRegex = /^((.|\n)*;)\s*(get;|get\s*.\w*;)/;
+  const getRegex = /^((.|\n)*;)\s*(get;|get(\s+\$[^\s]+)+?;)/;
   let limitedQuery = query;
 
   if (getRegex.test(query)) {

--- a/test/unit/components/Visualiser/VisualiserUtils.test.js
+++ b/test/unit/components/Visualiser/VisualiserUtils.test.js
@@ -38,6 +38,18 @@ describe('limit Query', () => {
     expect(limited).toBe('match $x isa person; get; offset 0; limit 10;');
   });
 
+  test('add offset and limit to a query with single get variable', () => {
+    const query = 'match $x isa person; get $x;';
+    const limited = limitQuery(query);
+    expect(limited).toBe('match $x isa person; get $x; offset 0; limit 10;');
+  });
+
+  test('add offset and limit to a query with multiple get variables', () => {
+    const query = 'match $x isa person, has age $a; get $x, $a;';
+    const limited = limitQuery(query);
+    expect(limited).toBe('match $x isa person, has age $a; get $x, $a; offset 0; limit 10;');
+  });
+
   test('add offset to query already containing limit', () => {
     const query = 'match $x isa person; get; limit 40;';
     const limited = limitQuery(query);


### PR DESCRIPTION
## What is the goal of this PR?
The change introduced in this PR, fixes the regex used in determining if the query should be extended with the `offset` and `limit` modifiers.