### PR TITLE
Improves presentation and logic of attributes displayed on a node's label

### DIFF
--- a/src/renderer/components/shared/CanvasDataBuilder.js
+++ b/src/renderer/components/shared/CanvasDataBuilder.js
@@ -101,6 +101,7 @@ const getNodeLabelWithAttrs = async (baseLabel, type, instance) => {
 
   if (selectedAttrs.length > 0) {
     const allAttrs = await (await convertToRemote(instance).attributes()).collect();
+
     const promises = allAttrs.map(async attr => new Promise((resolve) => {
       attr.type().then((type) => {
         type.label().then((label) => {
@@ -110,8 +111,13 @@ const getNodeLabelWithAttrs = async (baseLabel, type, instance) => {
         });
       });
     }));
+
     const allAttrsData = await Promise.all(promises);
-    const selectedAttrsData = allAttrsData.filter(attrData => selectedAttrs.includes(attrData.label));
+    const allAttrsMap = {};
+    allAttrsData.forEach((attrData) => { allAttrsMap[attrData.label] = attrData.value; });
+
+    // eslint-disable-next-line no-prototype-builtins
+    const selectedAttrsData = selectedAttrs.map(attrLabel => ({ label: attrLabel, value: allAttrsMap.hasOwnProperty(attrLabel) ? allAttrsMap[attrLabel] : '' }));
     label += selectedAttrsData.map(attrData => `\n${attrData.label}: ${attrData.value}`).join('');
   }
   return label;
@@ -517,7 +523,6 @@ const updateNodesLabel = async (nodes) => {
     node.label = updatedLabels[i];
     return node;
   });
-  debugger;
 
   return updatedNodes;
 };

--- a/src/renderer/components/shared/CanvasDataBuilder.js
+++ b/src/renderer/components/shared/CanvasDataBuilder.js
@@ -112,9 +112,8 @@ const getNodeLabelWithAttrs = async (baseLabel, type, instance) => {
     }));
     const allAttrsData = await Promise.all(promises);
     const selectedAttrsData = allAttrsData.filter(attrData => selectedAttrs.includes(attrData.label));
-    label += selectedAttrsData.map(attrData => `\n${attrData.label}: ${attrData.value}`).join();
+    label += selectedAttrsData.map(attrData => `\n${attrData.label}: ${attrData.value}`).join('');
   }
-
   return label;
 };
 
@@ -518,6 +517,7 @@ const updateNodesLabel = async (nodes) => {
     node.label = updatedLabels[i];
     return node;
   });
+  debugger;
 
   return updatedNodes;
 };

--- a/test/unit/components/shared/CanvasDataBuilder.test.js
+++ b/test/unit/components/shared/CanvasDataBuilder.test.js
@@ -1,4 +1,5 @@
 import CDB from '@/components/shared/CanvasDataBuilder';
+import { getTypeLabels } from '@/components/Visualiser/RightBar/SettingsTab/DisplaySettings';
 
 import {
   getMockedEntity,
@@ -20,7 +21,7 @@ jest.mock('@/components/Visualiser/RightBar/SettingsTab/QuerySettings', () => ({
 }));
 
 jest.mock('@/components/Visualiser/RightBar/SettingsTab/DisplaySettings', () => ({
-  getTypeLabels: () => ['attribute-type'],
+  getTypeLabels: jest.fn(() => []),
 }));
 
 jest.mock('@/components/shared/PersistentStorage', () => ({}));
@@ -127,6 +128,8 @@ describe('building instances', () => {
   });
 
   test('when graql answer contains an entity and one of its attributes has been selected in the DisplaySettings', async () => {
+    getTypeLabels.mockImplementation(() => ['attribute-type']);
+
     const attribute = getMockedAttribute();
     const entity = getMockedEntity({
       extraProps: {
@@ -140,6 +143,7 @@ describe('building instances', () => {
 
     const { nodes } = await CDB.buildInstances([answer]);
     expect(nodes[0].label).toEqual('entity-type: entity-id\nattribute-type: attribute-value');
+    getTypeLabels.mockImplementation(() => []);
   });
 
   test('when graql answer contains an explanation', async () => {


### PR DESCRIPTION
## What is the goal of this PR?
When selecting attribute labels in the Display settings for a given type, the attribute label is added to the nodes' label even though the instance (i.e. node) does not own an instance of the selected attribute type. In this case, the attribute's value is displayed as empty. In addition, commas are no longer displayed at the end of each attribute label/value on the node's label. 

## What are the changes implemented in this PR?
resolves https://github.com/graknlabs/workbase/issues/329
resolves https://github.com/graknlabs/workbase/issues/325