### PR TITLE
Adds Graql syntax highlighting for single quoted strings

### DIFF
--- a/src/renderer/components/Visualiser/TopBar/GraqlEditor/GraqlCodeMirror.js
+++ b/src/renderer/components/Visualiser/TopBar/GraqlEditor/GraqlCodeMirror.js
@@ -6,7 +6,7 @@ CodeMirror.defineSimpleMode('graql', {
   // The start state contains the rules that are intially used
   start: [
     { regex: /#.*/, token: 'comment' },
-    { regex: /".*?"/, token: 'string' },
+    { regex: /(".*?")|('.*?')/, token: 'string' },
     { regex: /(match|isa|isa!|sub|sub!|has|id|type|limit|offset|sort|asc|desc|get|compute|path|from|to)(?![-a-zA-Z_0-9])/, // eslint-disable-line max-len
       token: 'keyword' },
     { regex: /true|false/, token: 'number' },


### PR DESCRIPTION
## What is the goal of this PR?
Single quoted strings in Graql queries are now highlighted correctly as strings.

## What are the changes implemented in this PR?
resolves https://github.com/graknlabs/workbase/issues/326