### PR TITLE
Excludes already-visualised nodes before updating canvas upon explanation

### DIFF
--- a/src/renderer/components/Visualiser/store/actions.js
+++ b/src/renderer/components/Visualiser/store/actions.js
@@ -290,12 +290,14 @@ export default {
         finalExplAnswers = ruleExpl.map(expl => expl.getAnswers()).reduce(collect, []);
       }
 
-
       if (finalExplAnswers.length > 0) {
         const data = await CDB.buildInstances(finalExplAnswers);
         const rpData = await CDB.buildRPInstances(finalExplAnswers, data, false, graknTx);
         data.nodes.push(...rpData.nodes);
         data.edges.push(...rpData.edges);
+
+        // this is to avoid overriding the explanation object of nodes that are already visualised
+        data.nodes = data.nodes.filter(node => !state.visFacade.getNode().some(currNode => currNode.id === node.id));
 
         state.visFacade.addToCanvas(data);
         commit('updateCanvasData');


### PR DESCRIPTION
## What is the goal of this PR?
Explanation of an inferred concept that has previously been redrawn as part of a prior explanation now works as expected.

## What are the changes implemented in this PR?
to retain the original explanation object attached to each node, we now avoid updating existing nodes upon explanation.
resolves https://github.com/graknlabs/workbase/issues/331
