### PR TITLE
Add AppImage as a target for Linux

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ jobs:
       - checkout
       - run: bazel run @nodejs//:bin/yarn install
       - run: bazel run @nodejs//:bin/yarn run build
-      - run: mkdir -p ~/distribution && mv ./build/*.tar.gz ~/distribution/grakn-workbase-linux-$(cat VERSION).tar.gz
+      - run: mkdir -p ~/distribution && for ext in tar.gz AppImage; do mv ./build/*.$ext ~/distribution/grakn-workbase-linux-$(cat VERSION).$ext; done
       - persist_to_workspace:
           root: ~/distribution
           paths:

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -21,7 +21,9 @@ linux:
   artifactName: 'grakn-workbase-${version}-linux.${ext}'
   category: Development
   icon: assets/icons
-  target: tar.gz
+  target:
+    - tar.gz
+    - appimage
 mac:
   hardenedRuntime: true
   artifactName: 'grakn-workbase-${version}-mac.${ext}'


### PR DESCRIPTION
## What is the goal of this PR?

It has been really painful for me to try and get the tar.gz build to work.
After some struggle I managed to get the app to launch but the screen would be blank.
Building .AppImage and executing that worked like a charm. It launched, there was no blank screen and the UI was usable.

Benefits of using AppImage: https://docs.appimage.org/introduction/advantages.html#advantages-for-users

## What are the changes implemented in this PR?

Add AppImage as a target for Linux.