### PR TITLE
Fix ENTER key destroying visualiser window

### DIFF
--- a/src/components/Login/LoginPage.vue
+++ b/src/components/Login/LoginPage.vue
@@ -183,9 +183,10 @@ export default {
     },
   },
   created() {
-    window.addEventListener('keyup', (e) => {
-      if (e.keyCode === 13 && !e.shiftKey && this.serverHost && this.serverPort) this.connect();
-    });
+    // TODO: Figure out why this code causes ENTER key to destroy the whole visualiser window
+    // window.addEventListener('keyup', (e) => {
+    //   if (e.keyCode === 13 && !e.shiftKey && this.serverHost && this.serverPort) this.connect();
+    // });
   },
   mounted() {
     this.$nextTick(() => {


### PR DESCRIPTION
## What is the goal of this PR?

We fixed an issue where pressing ENTER caused the Visualiser window to disappear.

## What are the changes implemented in this PR?

Fix ENTER key destroying visualiser window
