### PR TITLE
Do not delete attributes when type doesn't own the attribute

### DIFF
--- a/src/components/SchemaDesign/store/actions.js
+++ b/src/components/SchemaDesign/store/actions.js
@@ -381,7 +381,9 @@ export default {
     } else if (payload.baseType === 'ATTRIBUTE_TYPE') {
       const nodes = state.visFacade.getAllNodes();
       await Promise.all(nodes.map(async (node) => {
-        await state.schemaHandler.deleteAttribute(node.typeLabel, payload.typeLabel);
+        if (node.attributes.some(x => x.typeLabel === payload.typeLabel)) {
+          await state.schemaHandler.deleteAttribute(node.typeLabel, payload.typeLabel);
+        }
         node.attributes = node.attributes.filter((x => x.typeLabel !== payload.typeLabel));
       }));
       state.visFacade.updateNode(nodes);


### PR DESCRIPTION
## What is the goal of this PR?

In 2.0 `deleteOwns` becomes stricter, which throws if type doesn't own the attribute. Do not delete attributes when the type to delete doesn't own the attribute.

## What are the changes implemented in this PR?

- Fix https://github.com/graknlabs/workbase/issues/380